### PR TITLE
Add TreatmentCategoryLinks Component to Navbar

### DIFF
--- a/components/Layout/Navbar.tsx
+++ b/components/Layout/Navbar.tsx
@@ -30,7 +30,33 @@ import { treatmentCategories, categoryIconMap } from '@/lib/data/treatments';
 import TreatmentCategoryLinks from './TreatmentCategoryLinks';
 import { cn } from '@/lib/utils';
 
+// --- Link Style Constants ---
+const desktopCategoryLinkClasses: string = "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground";
+const mobileCategoryLinkClasses: string = "text-sm text-muted-foreground hover:text-primary";
+// ---------------------------
+
 export default function Navbar() {
+  /**
+   * Navbar Component
+   * 
+   * A responsive navigation bar component that provides:
+   * - Desktop navigation with dropdown menus
+   * - Mobile navigation with a collapsible sheet
+   * - Treatment category navigation in both desktop and mobile views
+   * 
+   * Features:
+   * - Responsive design with mobile-first approach
+   * - Integration with TreatmentCategoryLinks component
+   * - Uses Radix UI components for accessibility
+   * 
+   * @component
+   * @example
+   * ```tsx
+   * <Navbar />
+   * ```
+   * 
+   * @returns {JSX.Element} A responsive navigation bar
+   */
   const [isMobileTreatmentsOpen, setIsMobileTreatmentsOpen] = useState(false);
 
   return (
@@ -81,7 +107,7 @@ export default function Navbar() {
                           <NavigationMenuLink asChild>
                             <Link
                               href={`/treatments/${category.slug}`}
-                              className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                              className={desktopCategoryLinkClasses}
                             >
                               <div className="flex items-center space-x-3">
                                 {IconComponent && <IconComponent className="h-4 w-4 flex-shrink-0 text-primary" />}
@@ -170,13 +196,13 @@ export default function Navbar() {
 
                   <CollapsibleContent>
                     <div className="flex flex-col space-y-2 pl-4 pt-2">
-                      <Link href="/treatments" className="text-sm text-muted-foreground hover:text-primary">
+                      <Link href="/treatments" className={mobileCategoryLinkClasses}>
                         All Treatments
                       </Link>
                       <TreatmentCategoryLinks 
                         categories={treatmentCategories} 
                         showIcon={true}
-                        baseLinkClasses="text-sm text-muted-foreground hover:text-primary"
+                        baseLinkClasses={mobileCategoryLinkClasses}
                         textClasses=""
                         iconClasses="h-4 w-4 flex-shrink-0 text-primary pr-0.5"
                       />

--- a/components/Layout/Navbar.tsx
+++ b/components/Layout/Navbar.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/collapsible";
 import { Menu, ChevronRight, ChevronDown } from 'lucide-react';
 import { treatmentCategories, categoryIconMap } from '@/lib/data/treatments';
+import TreatmentCategoryLinks from './TreatmentCategoryLinks';
 import { cn } from '@/lib/utils';
 
 export default function Navbar() {
@@ -35,6 +36,7 @@ export default function Navbar() {
   return (
     <header className="w-full border-b bg-secondary/15 backdrop-blur supports-[backdrop-filter]:bg-secondary/15 sticky z-40">
       <nav className="container flex h-16 items-center">
+        
         {/* Left Navigation Menu - Desktop */}
         <div className="hidden lg:flex items-center space-x-6">
           <NavigationMenu className="relative z-50 pl-2">
@@ -74,13 +76,12 @@ export default function Navbar() {
                     </li>
                     {treatmentCategories.map((category) => {
                       const IconComponent = category.iconName ? categoryIconMap[category.iconName] : null;
-
                       return (
                         <li key={category.id}>
                           <NavigationMenuLink asChild>
                             <Link
-                              className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
                               href={`/treatments/${category.slug}`}
+                              className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
                             >
                               <div className="flex items-center space-x-3">
                                 {IconComponent && <IconComponent className="h-4 w-4 flex-shrink-0 text-primary" />}
@@ -172,22 +173,13 @@ export default function Navbar() {
                       <Link href="/treatments" className="text-sm text-muted-foreground hover:text-primary">
                         All Treatments
                       </Link>
-                      {treatmentCategories.map((category) => {
-                        const IconComponent = category.iconName ? categoryIconMap[category.iconName] : null;
-
-                        return (
-                          <Link
-                            key={category.id}
-                            href={`/treatments/${category.slug}`}
-                            className="text-sm text-muted-foreground hover:text-primary"
-                          >
-                            <div className="flex items-center space-x-3">
-                              {IconComponent && <IconComponent className="h-4 w-4 flex-shrink-0 text-primary pr-0.5" />}
-                              {category.name}
-                            </div>
-                          </Link>
-                        );
-                      })}
+                      <TreatmentCategoryLinks 
+                        categories={treatmentCategories} 
+                        showIcon={true}
+                        baseLinkClasses="text-sm text-muted-foreground hover:text-primary"
+                        textClasses=""
+                        iconClasses="h-4 w-4 flex-shrink-0 text-primary pr-0.5"
+                      />
                     </div>
                   </CollapsibleContent>
                 </Collapsible>

--- a/components/Layout/TreatmentCategoryLinks.tsx
+++ b/components/Layout/TreatmentCategoryLinks.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Link from 'next/link';
+import { TreatmentCategory, categoryIconMap } from '@/lib/data/treatments';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  categories: TreatmentCategory[];
+  baseLinkClasses?: string; // Base classes for all links
+  iconClasses?: string; // Classes specifically for the icon
+  textClasses?: string; // Classes specifically for the text
+  showIcon?: boolean;
+}
+
+export default function TreatmentCategoryLinks({ 
+    categories, 
+    baseLinkClasses = '',
+    iconClasses = 'h-4 w-4 flex-shrink-0 text-primary',
+    textClasses = 'text-sm font-medium leading-none',
+    showIcon = false 
+}: Props) {
+  return (
+    <>
+      {categories.map((category) => {
+        const IconComponent = category.iconName ? categoryIconMap[category.iconName] : null;
+        return (
+          <Link
+            key={category.id}
+            href={`/treatments/${category.slug}`}
+            className={cn('flex items-center space-x-2', baseLinkClasses)} // Combine base classes
+          >
+            {showIcon && IconComponent && <IconComponent className={cn(iconClasses)} />} 
+            <span className={cn(textClasses)}>{category.name}</span>
+          </Link>
+        );
+      })}
+    </>
+  );
+} 


### PR DESCRIPTION
Refactor treatment category links rendering in Navbar by introducing a new reusable TreatmentCategoryLinks component

New Features:
- Created a flexible TreatmentCategoryLinks component that can render treatment category links with configurable styling and optional icons

Enhancements:
- Improved code modularity by extracting treatment category link rendering logic into a separate component
- Added configurable styling options for treatment category links in both desktop and mobile views

Chores:
- Extracted link styling constants to improve code readability
- Updated Navbar component to use the new TreatmentCategoryLinks component