### PR TITLE
Add redirects for treatment categories in next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,6 +15,44 @@ const nextConfig = {
       // You can add other rewrite rules here if needed
     ];
   },
+  redirects: async () => [
+    {
+      source: '/facials',
+      destination: '/treatments?category=facials',
+      permanent: true,
+    },
+    {
+      source: '/seasonal-treatments',
+      destination: '/treatments?category=seasonal-treatments',
+      permanent: true,
+    },
+    {
+      source: '/reflexology',
+      destination: '/treatments?category=reflexology',
+      permanent: true,
+    },
+    {
+      source: '/massage-kelso-scottish-borders',
+      destination: '/treatments?category=massage',
+      permanent: true,
+    },
+    {
+      source: '/body-treatments',
+      destination: '/treatments?category=body-treatments',
+      permanent: true,
+    },
+    {
+      source: '/book-treatments',
+      destination: '/treatments',
+      permanent: true,
+    },
+    
+    
+    
+    
+    
+    
+  ],
 };
 
 // Use ES Module export syntax


### PR DESCRIPTION
- Implemented new redirect rules for various treatment categories, enhancing user navigation and SEO.
- Added permanent redirects for '/facials', '/seasonal-treatments', '/reflexology', '/massage-kelso-scottish-borders', '/body-treatments', and '/book-treatments' to their respective treatment pages.

These changes improve the user experience by ensuring users are directed to the correct treatment categories seamlessly.

## Summary by Sourcery

Add permanent redirects for various treatment category pages to improve user navigation and SEO

New Features:
- Created permanent redirects for multiple treatment-related URLs to their corresponding treatment pages

Enhancements:
- Implemented a comprehensive set of URL redirects to streamline user access to treatment categories