### PR TITLE
Update ContactForm placeholder text for clarity and inclusivity

### DIFF
--- a/components/Contact/ContactForm.tsx
+++ b/components/Contact/ContactForm.tsx
@@ -276,7 +276,7 @@ export default function ContactForm({ initialTreatment }: ContactFormProps) {
               <FormLabel>Message *</FormLabel>
               <FormControl>
                 <Textarea 
-                  placeholder="Please let me know of any allergies or medical conditions ie. pregnancy"
+                  placeholder="Please let me know of any allergies or medical conditions ie. pregnancy. Sorry, not currently offering treatments for male customers."
                   className="resize-none min-h-[120px]" 
                   {...field} 
                 />


### PR DESCRIPTION
- Modified the placeholder in the message textarea to include a note about the current limitation of not offering treatments for male customers.
- This change aims to provide clearer communication regarding service availability to potential clients.