### PR TITLE
Fix stretched images on treatments page

### DIFF
--- a/components/Treatments/TreatmentCard.tsx
+++ b/components/Treatments/TreatmentCard.tsx
@@ -65,7 +65,7 @@ const TreatmentCard = memo<TreatmentCardProps>(({ treatment }) => {
             src={treatment.image}
             alt={treatment.title}
             fill
-            aspectRatio="4/3"
+            skipAutoAspectRatio
             style={{ objectFit: 'cover' }}
             className="transition-transform duration-300 group-hover:scale-105"
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"


### PR DESCRIPTION
Treatment card images were stretching due to conflict between fixed height container (h-52) and aspectRatio prop (4/3). Using skipAutoAspectRatio allows images to fill fixed-height containers naturally with objectFit: cover.

Resolves image stretching issue on /treatments page.