### PR TITLE
fix(seo): Use openingHoursSpecification with @type for Schema.org validation

### DIFF
--- a/lib/jsonLsUtils.ts
+++ b/lib/jsonLsUtils.ts
@@ -53,7 +53,12 @@ export function generateServiceJsonLd(treatment: Treatment, contactInfo: Contact
             address: contactInfo.address,
             telephone: contactInfo.phone,
             email: contactInfo.email,
-            openingHoursSpecification: contactInfo.openingHours,
+            openingHoursSpecification: contactInfo.openingHours.map(hours => ({
+                '@type': 'OpeningHoursSpecification',
+                dayOfWeek: hours.dayOfWeek,
+                opens: hours.opens,
+                closes: hours.closes,
+            })),
             hasMap: contactInfo.mapSrc,
         },
         timeRequired: treatment.duration,
@@ -102,7 +107,12 @@ export function generateHealthAndBeautyBusinessJsonLd(
         address: contactInfo.address,
         telephone: contactInfo.phone,
         email: contactInfo.email,
-        openingHours: contactInfo.openingHours,
+        openingHoursSpecification: contactInfo.openingHours.map(hours => ({
+            '@type': 'OpeningHoursSpecification',
+            dayOfWeek: hours.dayOfWeek,
+            opens: hours.opens,
+            closes: hours.closes,
+        })),
         hasMap: contactInfo.mapSrc,
         geo: {
             '@type': 'GeoCoordinates',


### PR DESCRIPTION
## Summary

Fixes Schema.org validation error:
> OpeningHoursSpecification is not a known valid target type for the openingHours property

## Changes

- Change `openingHours` to `openingHoursSpecification` in `HealthAndBeautyBusiness` schema
- Add `@type: 'OpeningHoursSpecification'` to each opening hours object
- Apply same fix to `Service` schema's provider

## Schema.org Context

According to Schema.org:
- `openingHours` expects a **Text** type (string like "Mo-Fr 09:00-17:00")
- `openingHoursSpecification` expects an **OpeningHoursSpecification** object with `@type`

## Files Changed

- `lib/jsonLsUtils.ts` - Fix both `generateHealthAndBeautyBusinessJsonLd` and `generateServiceJsonLd`

## Test Plan

- [x] TypeScript passes
- [x] All SEO tests pass (19/19)
- [x] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [x] Validate with [Schema.org Validator](https://validator.schema.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)