### PR TITLE
feat: Add promotional dialog with Sanity CMS and GA4 tracking

### DIFF
--- a/__tests__/components/Layout/PromotionalDialog.test.tsx
+++ b/__tests__/components/Layout/PromotionalDialog.test.tsx
@@ -261,6 +261,23 @@ describe('PromotionalDialog', () => {
       });
     });
 
+    it('does not fire promo_dialog_dismiss when CTA click closes dialog', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      mockTrackEvent.mockClear();
+      await user.click(screen.getByRole('link', { name: 'Book Now' }));
+
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        'promo_dialog_dismiss',
+        expect.anything()
+      );
+    });
+
     it('fires promo_dialog_dismiss when "No thanks" is clicked', async () => {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       render(<PromotionalDialog offer={mockOffer} />);

--- a/__tests__/components/Layout/PromotionalDialog.test.tsx
+++ b/__tests__/components/Layout/PromotionalDialog.test.tsx
@@ -96,7 +96,7 @@ describe('PromotionalDialog', () => {
 
       expect(screen.getByText('Spring Special')).toBeInTheDocument();
 
-      await user.click(screen.getByRole('button', { name: /no thanks/i }));
+      await user.click(screen.getByRole('button', { name: /dismiss promotional offer/i }));
 
       expect(screen.queryByText('Spring Special')).not.toBeInTheDocument();
     });
@@ -109,7 +109,7 @@ describe('PromotionalDialog', () => {
         vi.advanceTimersByTime(3000);
       });
 
-      await user.click(screen.getByRole('button', { name: /no thanks/i }));
+      await user.click(screen.getByRole('button', { name: /dismiss promotional offer/i }));
 
       const stored = localStorage.getItem('promo_dismissed_promo-1');
       expect(stored).not.toBeNull();
@@ -270,7 +270,7 @@ describe('PromotionalDialog', () => {
       });
 
       mockTrackEvent.mockClear();
-      await user.click(screen.getByRole('button', { name: /no thanks/i }));
+      await user.click(screen.getByRole('button', { name: /dismiss promotional offer/i }));
 
       expect(mockTrackEvent).toHaveBeenCalledWith('promo_dialog_dismiss', {
         offer_id: 'promo-1',

--- a/__tests__/components/Layout/PromotionalDialog.test.tsx
+++ b/__tests__/components/Layout/PromotionalDialog.test.tsx
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PromotionalDialog } from '@/components/Layout/PromotionalDialog';
+import { PromotionalOffer } from '@/lib/data/promotionalOffer';
+import { trackEvent } from '@/lib/analytics/ga4';
+
+vi.mock('@/lib/analytics/ga4', () => ({
+  trackEvent: vi.fn(),
+}));
+
+const mockTrackEvent = vi.mocked(trackEvent);
+
+const mockOffer: PromotionalOffer = {
+  id: 'promo-1',
+  title: 'Spring Special',
+  description: 'Get 20% off all facials this spring!',
+  image: 'https://cdn.sanity.io/images/test/production/mock-image.jpg',
+  imageAlt: 'Spring flowers',
+  ctaText: 'Book Now',
+  ctaLink: '/contact',
+  dismissDurationDays: 7,
+  displayDelaySeconds: 3,
+};
+
+const mockOfferExternal: PromotionalOffer = {
+  ...mockOffer,
+  ctaLink: 'https://example.com/book',
+};
+
+const mockOfferNoImage: PromotionalOffer = {
+  ...mockOffer,
+  image: undefined,
+  imageAlt: undefined,
+};
+
+describe('PromotionalDialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    localStorage.clear();
+    mockTrackEvent.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('Visibility & Timing', () => {
+    it('is NOT visible immediately after render', () => {
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      expect(
+        screen.queryByText('Spring Special')
+      ).not.toBeInTheDocument();
+    });
+
+    it('becomes visible after the configured delay', async () => {
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      // Not visible before delay
+      expect(screen.queryByText('Spring Special')).not.toBeInTheDocument();
+
+      // Advance past the 3-second delay
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(screen.getByText('Spring Special')).toBeInTheDocument();
+    });
+
+    it('shows the offer title, description, and CTA button text', async () => {
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(screen.getByText('Spring Special')).toBeInTheDocument();
+      expect(
+        screen.getByText('Get 20% off all facials this spring!')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Book Now' })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Dismissal behavior', () => {
+    it('hides the dialog when clicking "No thanks"', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(screen.getByText('Spring Special')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /no thanks/i }));
+
+      expect(screen.queryByText('Spring Special')).not.toBeInTheDocument();
+    });
+
+    it('records dismissal to localStorage when dismissed', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      await user.click(screen.getByRole('button', { name: /no thanks/i }));
+
+      const stored = localStorage.getItem('promo_dismissed_promo-1');
+      expect(stored).not.toBeNull();
+    });
+
+    it('does not show dialog when localStorage has a recent dismissal', async () => {
+      // Set a recent dismissal (within dismissDurationDays)
+      localStorage.setItem(
+        'promo_dismissed_promo-1',
+        JSON.stringify({ timestamp: Date.now() })
+      );
+
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(screen.queryByText('Spring Special')).not.toBeInTheDocument();
+    });
+
+    it('shows dialog when localStorage dismissal has expired', async () => {
+      // Set an expired dismissal (8 days ago, dismissDurationDays is 7)
+      const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+      localStorage.setItem(
+        'promo_dismissed_promo-1',
+        JSON.stringify({ timestamp: eightDaysAgo })
+      );
+
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(screen.getByText('Spring Special')).toBeInTheDocument();
+    });
+  });
+
+  describe('Content rendering', () => {
+    it('shows image when provided', async () => {
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      const image = screen.getByRole('img', { name: 'Spring flowers' });
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute(
+        'src',
+        expect.stringContaining('mock-image')
+      );
+    });
+
+    it('does not show image element when absent', async () => {
+      render(<PromotionalDialog offer={mockOfferNoImage} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    });
+
+    it('CTA link has correct href', async () => {
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      const ctaLink = screen.getByRole('link', { name: 'Book Now' });
+      expect(ctaLink).toHaveAttribute('href', '/contact');
+    });
+
+    it('external links open in new tab', async () => {
+      render(<PromotionalDialog offer={mockOfferExternal} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      const ctaLink = screen.getByRole('link', { name: 'Book Now' });
+      expect(ctaLink).toHaveAttribute('target', '_blank');
+      expect(ctaLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('internal links do NOT have target="_blank"', async () => {
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      const ctaLink = screen.getByRole('link', { name: 'Book Now' });
+      expect(ctaLink).not.toHaveAttribute('target', '_blank');
+    });
+  });
+
+  describe('CTA behavior', () => {
+    it('CTA button records dismissal so dialog will not reappear', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      await user.click(screen.getByRole('link', { name: 'Book Now' }));
+
+      const stored = localStorage.getItem('promo_dismissed_promo-1');
+      expect(stored).not.toBeNull();
+    });
+  });
+
+  describe('GA4 event tracking', () => {
+    it('fires promo_dialog_view when dialog opens after delay', async () => {
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith('promo_dialog_view', {
+        offer_id: 'promo-1',
+        offer_title: 'Spring Special',
+      });
+    });
+
+    it('fires promo_dialog_cta_click when CTA is clicked', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      mockTrackEvent.mockClear();
+      await user.click(screen.getByRole('link', { name: 'Book Now' }));
+
+      expect(mockTrackEvent).toHaveBeenCalledWith('promo_dialog_cta_click', {
+        offer_id: 'promo-1',
+        offer_title: 'Spring Special',
+        cta_text: 'Book Now',
+        cta_link: '/contact',
+      });
+    });
+
+    it('fires promo_dialog_dismiss when "No thanks" is clicked', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      mockTrackEvent.mockClear();
+      await user.click(screen.getByRole('button', { name: /no thanks/i }));
+
+      expect(mockTrackEvent).toHaveBeenCalledWith('promo_dialog_dismiss', {
+        offer_id: 'promo-1',
+        offer_title: 'Spring Special',
+      });
+    });
+
+    it('does not fire promo_dialog_view when dialog is suppressed by dismissal', async () => {
+      localStorage.setItem(
+        'promo_dismissed_promo-1',
+        JSON.stringify({ timestamp: Date.now() })
+      );
+
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/components/Layout/PromotionalDialog.test.tsx
+++ b/__tests__/components/Layout/PromotionalDialog.test.tsx
@@ -131,6 +131,19 @@ describe('PromotionalDialog', () => {
       expect(screen.queryByText('Spring Special')).not.toBeInTheDocument();
     });
 
+    it('shows dialog and cleans up when localStorage has malformed JSON', async () => {
+      localStorage.setItem('promo_dismissed_promo-1', '{not valid json');
+
+      render(<PromotionalDialog offer={mockOffer} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(screen.getByText('Spring Special')).toBeInTheDocument();
+      expect(localStorage.getItem('promo_dismissed_promo-1')).toBeNull();
+    });
+
     it('shows dialog when localStorage dismissal has expired', async () => {
       // Set an expired dismissal (8 days ago, dismissDurationDays is 7)
       const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;

--- a/__tests__/lib/cms/promotionalOffer.test.ts
+++ b/__tests__/lib/cms/promotionalOffer.test.ts
@@ -24,7 +24,7 @@ const mockSanityOffer: SanityPromotionalOffer = {
   _id: 'promo-1',
   title: 'Spring Special',
   description: 'Get 20% off all facials this spring!',
-  image: { asset: { _ref: 'image-abc123' }, alt: 'Spring flowers' } as SanityPromotionalOffer['image'],
+  image: { asset: { _ref: 'image-abc123' }, alt: 'Spring flowers' } satisfies SanityPromotionalOffer['image'],
   ctaText: 'Book Now',
   ctaLink: '/contact',
   isActive: true,

--- a/__tests__/lib/cms/promotionalOffer.test.ts
+++ b/__tests__/lib/cms/promotionalOffer.test.ts
@@ -48,6 +48,7 @@ describe('getActivePromotionalOffer', () => {
       description: 'Get 20% off all facials this spring!',
       image: 'https://cdn.sanity.io/images/test/production/mock-image.jpg',
       imageAlt: 'Spring flowers',
+      imageBlurDataURL: 'https://cdn.sanity.io/images/test/production/mock-image.jpg',
       ctaText: 'Book Now',
       ctaLink: '/contact',
       dismissDurationDays: 7,
@@ -80,5 +81,6 @@ describe('getActivePromotionalOffer', () => {
     expect(result).not.toBeNull();
     expect(result!.image).toBeUndefined();
     expect(result!.imageAlt).toBeUndefined();
+    expect(result!.imageBlurDataURL).toBeUndefined();
   });
 });

--- a/__tests__/lib/cms/promotionalOffer.test.ts
+++ b/__tests__/lib/cms/promotionalOffer.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getActivePromotionalOffer } from '@/lib/cms/promotionalOffer';
+import { sanityClient } from '@/lib/sanity/client';
+import { SanityPromotionalOffer } from '@/lib/sanity/types';
+
+// Mock the Sanity client
+vi.mock('@/lib/sanity/client', () => ({
+  sanityClient: {
+    fetch: vi.fn(),
+  },
+}));
+
+// Mock the image utility
+vi.mock('@/lib/sanity/image', () => ({
+  getImageUrl: vi.fn(
+    () => 'https://cdn.sanity.io/images/test/production/mock-image.jpg'
+  ),
+}));
+
+const mockSanityOffer: SanityPromotionalOffer = {
+  _id: 'promo-1',
+  title: 'Spring Special',
+  description: 'Get 20% off all facials this spring!',
+  image: { asset: { _ref: 'image-abc123' }, alt: 'Spring flowers' } as SanityPromotionalOffer['image'],
+  ctaText: 'Book Now',
+  ctaLink: '/contact',
+  isActive: true,
+  dismissDurationDays: 7,
+  displayDelaySeconds: 3,
+};
+
+describe('getActivePromotionalOffer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a transformed PromotionalOffer when Sanity returns an active offer', async () => {
+    vi.mocked(sanityClient.fetch).mockResolvedValue(mockSanityOffer as never);
+
+    const result = await getActivePromotionalOffer();
+
+    expect(result).toEqual({
+      id: 'promo-1',
+      title: 'Spring Special',
+      description: 'Get 20% off all facials this spring!',
+      image: 'https://cdn.sanity.io/images/test/production/mock-image.jpg',
+      imageAlt: 'Spring flowers',
+      ctaText: 'Book Now',
+      ctaLink: '/contact',
+      dismissDurationDays: 7,
+      displayDelaySeconds: 3,
+    });
+  });
+
+  it('returns null when Sanity returns no offer', async () => {
+    vi.mocked(sanityClient.fetch).mockResolvedValue(null as never);
+
+    const result = await getActivePromotionalOffer();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when Sanity fetch throws an error', async () => {
+    vi.mocked(sanityClient.fetch).mockRejectedValue(new Error('Network error'));
+
+    const result = await getActivePromotionalOffer();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns offer without image when image is not provided', async () => {
+    const offerWithoutImage = { ...mockSanityOffer, image: undefined };
+    vi.mocked(sanityClient.fetch).mockResolvedValue(offerWithoutImage as never);
+
+    const result = await getActivePromotionalOffer();
+
+    expect(result).not.toBeNull();
+    expect(result!.image).toBeUndefined();
+    expect(result!.imageAlt).toBeUndefined();
+  });
+});

--- a/__tests__/lib/cms/promotionalOffer.test.ts
+++ b/__tests__/lib/cms/promotionalOffer.test.ts
@@ -10,6 +10,9 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }));
 
+// Type the mock once here so individual tests don't need `as never` casts
+const mockFetch = sanityClient.fetch as unknown as ReturnType<typeof vi.fn>;
+
 // Mock the image utility
 vi.mock('@/lib/sanity/image', () => ({
   getImageUrl: vi.fn(
@@ -35,7 +38,7 @@ describe('getActivePromotionalOffer', () => {
   });
 
   it('returns a transformed PromotionalOffer when Sanity returns an active offer', async () => {
-    vi.mocked(sanityClient.fetch).mockResolvedValue(mockSanityOffer as never);
+    mockFetch.mockResolvedValue(mockSanityOffer);
 
     const result = await getActivePromotionalOffer();
 
@@ -53,7 +56,7 @@ describe('getActivePromotionalOffer', () => {
   });
 
   it('returns null when Sanity returns no offer', async () => {
-    vi.mocked(sanityClient.fetch).mockResolvedValue(null as never);
+    mockFetch.mockResolvedValue(null);
 
     const result = await getActivePromotionalOffer();
 
@@ -61,7 +64,7 @@ describe('getActivePromotionalOffer', () => {
   });
 
   it('returns null when Sanity fetch throws an error', async () => {
-    vi.mocked(sanityClient.fetch).mockRejectedValue(new Error('Network error'));
+    mockFetch.mockRejectedValue(new Error('Network error'));
 
     const result = await getActivePromotionalOffer();
 
@@ -70,7 +73,7 @@ describe('getActivePromotionalOffer', () => {
 
   it('returns offer without image when image is not provided', async () => {
     const offerWithoutImage = { ...mockSanityOffer, image: undefined };
-    vi.mocked(sanityClient.fetch).mockResolvedValue(offerWithoutImage as never);
+    mockFetch.mockResolvedValue(offerWithoutImage);
 
     const result = await getActivePromotionalOffer();
 

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -56,10 +56,17 @@ export async function POST(request: NextRequest) {
 
     console.log(`[Webhook] Verified webhook for type: ${_type}`);
 
-    // Revalidate all treatment pages (listing, category, and detail pages)
-    // Using 'layout' type revalidates /treatments and all nested routes beneath it
-    console.log(`[Webhook] Revalidating /treatments and all sub-pages for type: ${_type}`);
-    revalidatePath('/treatments', 'layout');
+    // Revalidate based on content type
+    if (_type === 'promotionalOffer') {
+      // Promotional offers appear in MainLayout (all pages), so revalidate the root layout
+      console.log(`[Webhook] Revalidating all pages for promotionalOffer update`);
+      revalidatePath('/', 'layout');
+    } else {
+      // Revalidate all treatment pages (listing, category, and detail pages)
+      // Using 'layout' type revalidates /treatments and all nested routes beneath it
+      console.log(`[Webhook] Revalidating /treatments and all sub-pages for type: ${_type}`);
+      revalidatePath('/treatments', 'layout');
+    }
 
     console.log('[Webhook] Revalidation completed successfully');
 

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 import {
   isValidSignature,
   SIGNATURE_HEADER_NAME,
@@ -58,9 +58,9 @@ export async function POST(request: NextRequest) {
 
     // Revalidate based on content type
     if (_type === 'promotionalOffer') {
-      // Promotional offers appear in MainLayout (all pages), so revalidate the root layout
-      console.log(`[Webhook] Revalidating all pages for promotionalOffer update`);
-      revalidatePath('/', 'layout');
+      // Use cache tag for targeted revalidation instead of full site
+      console.log(`[Webhook] Revalidating promotional-offer cache tag`);
+      revalidateTag('promotional-offer');
     } else {
       // Revalidate all treatment pages (listing, category, and detail pages)
       // Using 'layout' type revalidates /treatments and all nested routes beneath it

--- a/components/Layout/MainLayout.tsx
+++ b/components/Layout/MainLayout.tsx
@@ -25,7 +25,12 @@ export const MainLayout: React.FC<MainLayoutProps> = async ({ children }) => {
       <Footer />
       <CookieConsentWrapper />
       {promotionalOffer && (
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary
+          fallback={null}
+          onError={(error) => {
+            console.error('[PromotionalDialog] Render error:', error.message);
+          }}
+        >
           <PromotionalDialog offer={promotionalOffer} />
         </ErrorBoundary>
       )}

--- a/components/Layout/MainLayout.tsx
+++ b/components/Layout/MainLayout.tsx
@@ -25,12 +25,7 @@ export const MainLayout: React.FC<MainLayoutProps> = async ({ children }) => {
       <Footer />
       <CookieConsentWrapper />
       {promotionalOffer && (
-        <ErrorBoundary
-          fallback={null}
-          onError={(error) => {
-            console.error('[PromotionalDialog] Render error:', error.message);
-          }}
-        >
+        <ErrorBoundary fallback={null}>
           <PromotionalDialog offer={promotionalOffer} />
         </ErrorBoundary>
       )}

--- a/components/Layout/MainLayout.tsx
+++ b/components/Layout/MainLayout.tsx
@@ -3,6 +3,7 @@ import Navbar from '@/components/Layout/Navbar';
 import Footer from '@/components/Layout/Footer';
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import CookieConsentWrapper from '@/components/Layout/CookieConsentWrapper';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { getCategories } from '@/lib/cms/treatments';
 import { getActivePromotionalOffer } from '@/lib/cms/promotionalOffer';
 import { PromotionalDialog } from '@/components/Layout/PromotionalDialog';
@@ -23,7 +24,11 @@ export const MainLayout: React.FC<MainLayoutProps> = async ({ children }) => {
       <main className="flex-grow">{children}</main>
       <Footer />
       <CookieConsentWrapper />
-      {promotionalOffer && <PromotionalDialog offer={promotionalOffer} />}
+      {promotionalOffer && (
+        <ErrorBoundary fallback={null}>
+          <PromotionalDialog offer={promotionalOffer} />
+        </ErrorBoundary>
+      )}
       <SpeedInsights />
     </div>
   );

--- a/components/Layout/MainLayout.tsx
+++ b/components/Layout/MainLayout.tsx
@@ -4,13 +4,18 @@ import Footer from '@/components/Layout/Footer';
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import CookieConsentWrapper from '@/components/Layout/CookieConsentWrapper';
 import { getCategories } from '@/lib/cms/treatments';
+import { getActivePromotionalOffer } from '@/lib/cms/promotionalOffer';
+import { PromotionalDialog } from '@/components/Layout/PromotionalDialog';
 
 interface MainLayoutProps {
   children: ReactNode;
 }
 
 export const MainLayout: React.FC<MainLayoutProps> = async ({ children }) => {
-  const categories = await getCategories();
+  const [categories, promotionalOffer] = await Promise.all([
+    getCategories(),
+    getActivePromotionalOffer(),
+  ]);
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -18,6 +23,7 @@ export const MainLayout: React.FC<MainLayoutProps> = async ({ children }) => {
       <main className="flex-grow">{children}</main>
       <Footer />
       <CookieConsentWrapper />
+      {promotionalOffer && <PromotionalDialog offer={promotionalOffer} />}
       <SpeedInsights />
     </div>
   );

--- a/components/Layout/PromotionalDialog.tsx
+++ b/components/Layout/PromotionalDialog.tsx
@@ -105,6 +105,7 @@ export function PromotionalDialog({ offer }: PromotionalDialogProps) {
     if (isDismissed(offer.id, offer.dismissDurationDays)) return;
 
     const timer = setTimeout(() => {
+      if (isDismissed(offer.id, offer.dismissDurationDays)) return;
       hasShown.current = true;
       setOpen(true);
       trackEvent('promo_dialog_view', baseEventData);
@@ -134,6 +135,9 @@ export function PromotionalDialog({ offer }: PromotionalDialogProps) {
               fill
               className="object-cover"
               sizes="(max-width: 640px) 100vw, 32rem"
+              {...(offer.imageBlurDataURL
+                ? { placeholder: 'blur' as const, blurDataURL: offer.imageBlurDataURL }
+                : {})}
             />
           </div>
         )}

--- a/components/Layout/PromotionalDialog.tsx
+++ b/components/Layout/PromotionalDialog.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { PromotionalOffer } from '@/lib/data/promotionalOffer';
+import { trackEvent } from '@/lib/analytics/ga4';
+
+interface PromotionalDialogProps {
+  offer: PromotionalOffer;
+}
+
+function getStorageKey(offerId: string): string {
+  return `promo_dismissed_${offerId}`;
+}
+
+function isDismissed(offerId: string, dismissDurationDays: number): boolean {
+  try {
+    const stored = localStorage.getItem(getStorageKey(offerId));
+    if (!stored) return false;
+
+    const { timestamp } = JSON.parse(stored);
+    const dismissDurationMs = dismissDurationDays * 24 * 60 * 60 * 1000;
+    return Date.now() - timestamp < dismissDurationMs;
+  } catch {
+    return false;
+  }
+}
+
+function recordDismissal(offerId: string): void {
+  localStorage.setItem(
+    getStorageKey(offerId),
+    JSON.stringify({ timestamp: Date.now() })
+  );
+}
+
+function isExternalLink(url: string): boolean {
+  return url.startsWith('http://') || url.startsWith('https://');
+}
+
+export function PromotionalDialog({ offer }: PromotionalDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleDismiss = useCallback(() => {
+    trackEvent('promo_dialog_dismiss', {
+      offer_id: offer.id,
+      offer_title: offer.title,
+    });
+    recordDismissal(offer.id);
+    setOpen(false);
+  }, [offer.id, offer.title]);
+
+  useEffect(() => {
+    if (isDismissed(offer.id, offer.dismissDurationDays)) return;
+
+    const timer = setTimeout(() => {
+      setOpen(true);
+      trackEvent('promo_dialog_view', {
+        offer_id: offer.id,
+        offer_title: offer.title,
+      });
+    }, offer.displayDelaySeconds * 1000);
+
+    return () => clearTimeout(timer);
+  }, [offer.id, offer.dismissDurationDays, offer.displayDelaySeconds]);
+
+  const external = isExternalLink(offer.ctaLink);
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => {
+      if (!isOpen) handleDismiss();
+    }}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{offer.title}</DialogTitle>
+          <DialogDescription className="whitespace-pre-line">{offer.description}</DialogDescription>
+        </DialogHeader>
+
+        {offer.image && (
+          <div className="relative aspect-video w-full overflow-hidden rounded-md">
+            <Image
+              src={offer.image}
+              alt={offer.imageAlt ?? ''}
+              fill
+              className="object-cover"
+              sizes="(max-width: 640px) 100vw, 32rem"
+            />
+          </div>
+        )}
+
+        <DialogFooter className="flex-col gap-2 sm:flex-row">
+          <Button asChild>
+            <a
+              href={offer.ctaLink}
+              onClick={() => {
+                trackEvent('promo_dialog_cta_click', {
+                  offer_id: offer.id,
+                  offer_title: offer.title,
+                  cta_text: offer.ctaText,
+                  cta_link: offer.ctaLink,
+                });
+                recordDismissal(offer.id);
+              }}
+              {...(external
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
+              {offer.ctaText}
+            </a>
+          </Button>
+          <Button variant="ghost" onClick={handleDismiss}>
+            No thanks
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/Layout/PromotionalDialog.tsx
+++ b/components/Layout/PromotionalDialog.tsx
@@ -58,6 +58,9 @@ export function PromotionalDialog({ offer }: PromotionalDialogProps) {
     setOpen(false);
   }, [offer.id, offer.title]);
 
+  // Only `offer.id`, `dismissDurationDays`, and `displayDelaySeconds` drive the
+  // timer/dismissal logic. Other offer props (title, description, image, CTA) are
+  // read at render time and don't need to re-trigger the effect.
   useEffect(() => {
     if (isDismissed(offer.id, offer.dismissDurationDays)) return;
 
@@ -74,53 +77,58 @@ export function PromotionalDialog({ offer }: PromotionalDialogProps) {
 
   const external = isExternalLink(offer.ctaLink);
 
-  return (
-    <Dialog open={open} onOpenChange={(isOpen) => {
-      if (!isOpen) handleDismiss();
-    }}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>{offer.title}</DialogTitle>
-          <DialogDescription className="whitespace-pre-line">{offer.description}</DialogDescription>
-        </DialogHeader>
+  try {
+    return (
+      <Dialog open={open} onOpenChange={(isOpen) => {
+        if (!isOpen) handleDismiss();
+      }}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{offer.title}</DialogTitle>
+            <DialogDescription className="whitespace-pre-line">{offer.description}</DialogDescription>
+          </DialogHeader>
 
-        {offer.image && (
-          <div className="relative aspect-video w-full overflow-hidden rounded-md">
-            <Image
-              src={offer.image}
-              alt={offer.imageAlt ?? ''}
-              fill
-              className="object-cover"
-              sizes="(max-width: 640px) 100vw, 32rem"
-            />
-          </div>
-        )}
+          {offer.image && (
+            <div className="relative aspect-video w-full overflow-hidden rounded-md">
+              <Image
+                src={offer.image}
+                alt={offer.imageAlt ?? ''}
+                fill
+                className="object-cover"
+                sizes="(max-width: 640px) 100vw, 32rem"
+              />
+            </div>
+          )}
 
-        <DialogFooter className="flex-col gap-2 sm:flex-row">
-          <Button asChild>
-            <a
-              href={offer.ctaLink}
-              onClick={() => {
-                trackEvent('promo_dialog_cta_click', {
-                  offer_id: offer.id,
-                  offer_title: offer.title,
-                  cta_text: offer.ctaText,
-                  cta_link: offer.ctaLink,
-                });
-                recordDismissal(offer.id);
-              }}
-              {...(external
-                ? { target: '_blank', rel: 'noopener noreferrer' }
-                : {})}
-            >
-              {offer.ctaText}
-            </a>
-          </Button>
-          <Button variant="ghost" onClick={handleDismiss}>
-            No thanks
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
+          <DialogFooter className="flex-col gap-2 sm:flex-row">
+            <Button asChild>
+              <a
+                href={offer.ctaLink}
+                onClick={() => {
+                  trackEvent('promo_dialog_cta_click', {
+                    offer_id: offer.id,
+                    offer_title: offer.title,
+                    cta_text: offer.ctaText,
+                    cta_link: offer.ctaLink,
+                  });
+                  recordDismissal(offer.id);
+                }}
+                {...(external
+                  ? { target: '_blank', rel: 'noopener noreferrer' }
+                  : {})}
+              >
+                {offer.ctaText}
+              </a>
+            </Button>
+            <Button variant="ghost" onClick={handleDismiss}>
+              No thanks
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  } catch (error) {
+    console.error('[PromotionalDialog] Render error:', error);
+    return null;
+  }
 }

--- a/components/Layout/PromotionalDialog.tsx
+++ b/components/Layout/PromotionalDialog.tsx
@@ -59,6 +59,9 @@ function recordDismissal(offerId: string): void {
 }
 
 function isExternalLink(url: string): boolean {
+  if (url.startsWith('/') || url.startsWith('./') || url.startsWith('../')) {
+    return false;
+  }
   return url.startsWith('http://') || url.startsWith('https://');
 }
 

--- a/components/Layout/PromotionalDialog.tsx
+++ b/components/Layout/PromotionalDialog.tsx
@@ -24,6 +24,9 @@ interface PromotionalDialogProps {
 
 const STORAGE_KEY_PREFIX = 'promo_dismissed_';
 
+/** Upper bound for displayDelaySeconds (matches Sanity schema max validation) */
+const MAX_DISPLAY_DELAY_SECONDS = 30;
+
 function getStorageKey(offerId: string): string {
   return `${STORAGE_KEY_PREFIX}${offerId}`;
 }
@@ -64,7 +67,7 @@ function isExternalLink(url: string): boolean {
   if (url.startsWith('/') || url.startsWith('./') || url.startsWith('../')) {
     return false;
   }
-  return url.startsWith('http://') || url.startsWith('https://');
+  return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('//');
 }
 
 /** Sanitize URL by trimming whitespace and blocking dangerous schemes (XSS via CMS injection) */
@@ -114,7 +117,7 @@ export function PromotionalDialog({ offer }: PromotionalDialogProps) {
         offer_id: offer.id,
         offer_title: offer.title,
       });
-    }, Math.max(0, Math.min(30, offer.displayDelaySeconds)) * 1000);
+    }, Math.max(0, Math.min(MAX_DISPLAY_DELAY_SECONDS, offer.displayDelaySeconds)) * 1000);
 
     return () => clearTimeout(timer);
   }, [offer.id, offer.title, offer.dismissDurationDays, offer.displayDelaySeconds]);

--- a/components/Layout/PromotionalDialog.tsx
+++ b/components/Layout/PromotionalDialog.tsx
@@ -12,7 +12,11 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { PromotionalOffer } from '@/lib/data/promotionalOffer';
-import { trackEvent } from '@/lib/analytics/ga4';
+import {
+  trackEvent,
+  type PromoDialogEventData,
+  type PromoDialogCTAClickData,
+} from '@/lib/analytics/ga4';
 
 interface PromotionalDialogProps {
   offer: PromotionalOffer;
@@ -51,11 +55,13 @@ function isExternalLink(url: string): boolean {
 export function PromotionalDialog({ offer }: PromotionalDialogProps) {
   const [open, setOpen] = useState(false);
 
+  const baseEventData: PromoDialogEventData = {
+    offer_id: offer.id,
+    offer_title: offer.title,
+  };
+
   const handleDismiss = useCallback(() => {
-    trackEvent('promo_dialog_dismiss', {
-      offer_id: offer.id,
-      offer_title: offer.title,
-    });
+    trackEvent('promo_dialog_dismiss', baseEventData);
     recordDismissal(offer.id);
     setOpen(false);
   }, [offer.id, offer.title]);
@@ -65,10 +71,7 @@ export function PromotionalDialog({ offer }: PromotionalDialogProps) {
 
     const timer = setTimeout(() => {
       setOpen(true);
-      trackEvent('promo_dialog_view', {
-        offer_id: offer.id,
-        offer_title: offer.title,
-      });
+      trackEvent('promo_dialog_view', baseEventData);
     }, offer.displayDelaySeconds * 1000);
 
     return () => clearTimeout(timer);
@@ -103,12 +106,12 @@ export function PromotionalDialog({ offer }: PromotionalDialogProps) {
             <a
               href={offer.ctaLink}
               onClick={() => {
-                trackEvent('promo_dialog_cta_click', {
-                  offer_id: offer.id,
-                  offer_title: offer.title,
+                const ctaData: PromoDialogCTAClickData = {
+                  ...baseEventData,
                   cta_text: offer.ctaText,
                   cta_link: offer.ctaLink,
-                });
+                };
+                trackEvent('promo_dialog_cta_click', ctaData);
                 recordDismissal(offer.id);
               }}
               {...(external

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -72,7 +72,7 @@ function DialogContent({
             data-slot="dialog-close"
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
-            <XIcon />
+            <XIcon aria-hidden="true" />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}

--- a/lib/analytics/ga4.ts
+++ b/lib/analytics/ga4.ts
@@ -65,6 +65,22 @@ export interface FormInteractionData {
   error_message?: string;
 }
 
+/**
+ * Promotional dialog view/dismiss event data
+ */
+export interface PromoDialogEventData extends Record<string, unknown> {
+  offer_id: string;
+  offer_title: string;
+}
+
+/**
+ * Promotional dialog CTA click event data
+ */
+export interface PromoDialogCTAClickData extends PromoDialogEventData {
+  cta_text: string;
+  cta_link: string;
+}
+
 // ============================================================================
 // Constants
 // ============================================================================

--- a/lib/cms/promotionalOffer.ts
+++ b/lib/cms/promotionalOffer.ts
@@ -4,6 +4,9 @@ import { getImageUrl } from '@/lib/sanity/image';
 import { SanityPromotionalOffer } from '@/lib/sanity/types';
 import { PromotionalOffer } from '@/lib/data/promotionalOffer';
 
+/** Max width for promotional dialog images (mobile: 100vw, desktop: 32rem) */
+const PROMO_IMAGE_WIDTH = 600;
+
 /**
  * Transform Sanity promotional offer to app format
  */
@@ -15,7 +18,7 @@ function transformPromotionalOffer(
     title: sanityOffer.title,
     description: sanityOffer.description,
     image: sanityOffer.image
-      ? getImageUrl(sanityOffer.image, 600, undefined, 90)
+      ? getImageUrl(sanityOffer.image, PROMO_IMAGE_WIDTH, undefined, 90)
       : undefined,
     imageAlt: sanityOffer.image?.alt ?? undefined,
     ctaText: sanityOffer.ctaText,

--- a/lib/cms/promotionalOffer.ts
+++ b/lib/cms/promotionalOffer.ts
@@ -1,0 +1,43 @@
+import { sanityClient } from '@/lib/sanity/client';
+import { activePromotionalOfferQuery } from '@/lib/sanity/queries';
+import { getImageUrl } from '@/lib/sanity/image';
+import { SanityPromotionalOffer } from '@/lib/sanity/types';
+import { PromotionalOffer } from '@/lib/data/promotionalOffer';
+
+/**
+ * Transform Sanity promotional offer to app format
+ */
+function transformPromotionalOffer(
+  sanityOffer: SanityPromotionalOffer
+): PromotionalOffer {
+  return {
+    id: sanityOffer._id,
+    title: sanityOffer.title,
+    description: sanityOffer.description,
+    image: sanityOffer.image
+      ? getImageUrl(sanityOffer.image, 600, undefined, 90)
+      : undefined,
+    imageAlt: sanityOffer.image?.alt ?? undefined,
+    ctaText: sanityOffer.ctaText,
+    ctaLink: sanityOffer.ctaLink,
+    dismissDurationDays: sanityOffer.dismissDurationDays,
+    displayDelaySeconds: sanityOffer.displayDelaySeconds,
+  };
+}
+
+/**
+ * Fetch the currently active promotional offer from Sanity
+ * Returns null if no active offer exists or on error
+ */
+export async function getActivePromotionalOffer(): Promise<PromotionalOffer | null> {
+  try {
+    const offer =
+      await sanityClient.fetch<SanityPromotionalOffer | null>(
+        activePromotionalOfferQuery
+      );
+    return offer ? transformPromotionalOffer(offer) : null;
+  } catch (error) {
+    console.error('Error fetching promotional offer from Sanity:', error);
+    return null;
+  }
+}

--- a/lib/cms/promotionalOffer.ts
+++ b/lib/cms/promotionalOffer.ts
@@ -7,6 +7,9 @@ import { PromotionalOffer } from '@/lib/data/promotionalOffer';
 /** Max width for promotional dialog images (matches sizes prop: 640px mobile breakpoint) */
 const PROMO_IMAGE_WIDTH = 640;
 
+/** Tiny image width for blur placeholder */
+const PROMO_BLUR_WIDTH = 20;
+
 /**
  * Transform Sanity promotional offer to app format
  */
@@ -21,6 +24,9 @@ function transformPromotionalOffer(
       ? getImageUrl(sanityOffer.image, PROMO_IMAGE_WIDTH, undefined, 90)
       : undefined,
     imageAlt: sanityOffer.image?.alt ?? undefined,
+    imageBlurDataURL: sanityOffer.image
+      ? getImageUrl(sanityOffer.image, PROMO_BLUR_WIDTH, undefined, 30)
+      : undefined,
     ctaText: sanityOffer.ctaText,
     ctaLink: sanityOffer.ctaLink,
     dismissDurationDays: sanityOffer.dismissDurationDays,

--- a/lib/cms/promotionalOffer.ts
+++ b/lib/cms/promotionalOffer.ts
@@ -48,7 +48,8 @@ export async function getActivePromotionalOffer(): Promise<PromotionalOffer | nu
       );
     return offer ? transformPromotionalOffer(offer) : null;
   } catch (error) {
-    console.error('Error fetching promotional offer from Sanity:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error(`[Sanity] Failed to fetch promotional offer: ${message}`);
     return null;
   }
 }

--- a/lib/cms/promotionalOffer.ts
+++ b/lib/cms/promotionalOffer.ts
@@ -4,8 +4,8 @@ import { getImageUrl } from '@/lib/sanity/image';
 import { SanityPromotionalOffer } from '@/lib/sanity/types';
 import { PromotionalOffer } from '@/lib/data/promotionalOffer';
 
-/** Max width for promotional dialog images (mobile: 100vw, desktop: 32rem) */
-const PROMO_IMAGE_WIDTH = 600;
+/** Max width for promotional dialog images (matches sizes prop: 640px mobile breakpoint) */
+const PROMO_IMAGE_WIDTH = 640;
 
 /**
  * Transform Sanity promotional offer to app format
@@ -38,7 +38,7 @@ export async function getActivePromotionalOffer(): Promise<PromotionalOffer | nu
       await sanityClient.fetch<SanityPromotionalOffer | null>(
         activePromotionalOfferQuery,
         {},
-        { next: { revalidate: 3600 } }
+        { next: { revalidate: 3600, tags: ['promotional-offer'] } }
       );
     return offer ? transformPromotionalOffer(offer) : null;
   } catch (error) {

--- a/lib/cms/promotionalOffer.ts
+++ b/lib/cms/promotionalOffer.ts
@@ -36,7 +36,9 @@ export async function getActivePromotionalOffer(): Promise<PromotionalOffer | nu
   try {
     const offer =
       await sanityClient.fetch<SanityPromotionalOffer | null>(
-        activePromotionalOfferQuery
+        activePromotionalOfferQuery,
+        {},
+        { next: { revalidate: 3600 } }
       );
     return offer ? transformPromotionalOffer(offer) : null;
   } catch (error) {

--- a/lib/data/promotionalOffer.ts
+++ b/lib/data/promotionalOffer.ts
@@ -1,0 +1,14 @@
+/**
+ * App-level promotional offer type (transformed from Sanity response)
+ */
+export interface PromotionalOffer {
+  id: string;
+  title: string;
+  description: string;
+  image?: string;
+  imageAlt?: string;
+  ctaText: string;
+  ctaLink: string;
+  dismissDurationDays: number;
+  displayDelaySeconds: number;
+}

--- a/lib/data/promotionalOffer.ts
+++ b/lib/data/promotionalOffer.ts
@@ -7,6 +7,7 @@ export interface PromotionalOffer {
   description: string;
   image?: string;
   imageAlt?: string;
+  imageBlurDataURL?: string;
   ctaText: string;
   ctaLink: string;
   dismissDurationDays: number;

--- a/lib/sanity/queries.ts
+++ b/lib/sanity/queries.ts
@@ -117,8 +117,10 @@ export const allCategorySlugsQuery = groq`
 `;
 
 /**
- * GROQ query to fetch the active promotional offer
- * Filters by isActive, and optionally by startDate/endDate using now()
+ * GROQ query to fetch the active promotional offer.
+ * Filters by isActive, and optionally by startDate/endDate using now().
+ * If multiple offers are active simultaneously, returns the most recently
+ * created one (ordered by _createdAt desc, taking [0]).
  */
 export const activePromotionalOfferQuery = groq`
   *[_type == "promotionalOffer"

--- a/lib/sanity/queries.ts
+++ b/lib/sanity/queries.ts
@@ -115,3 +115,24 @@ export const allCategorySlugsQuery = groq`
     "slug": slug.current
   }
 `;
+
+/**
+ * GROQ query to fetch the active promotional offer
+ * Filters by isActive, and optionally by startDate/endDate using now()
+ */
+export const activePromotionalOfferQuery = groq`
+  *[_type == "promotionalOffer"
+    && isActive == true
+    && (!defined(startDate) || startDate <= now())
+    && (!defined(endDate) || endDate >= now())
+  ] | order(_createdAt desc) [0] {
+    _id,
+    title,
+    description,
+    image,
+    ctaText,
+    ctaLink,
+    dismissDurationDays,
+    displayDelaySeconds
+  }
+`;

--- a/lib/sanity/queries.ts
+++ b/lib/sanity/queries.ts
@@ -131,7 +131,7 @@ export const activePromotionalOfferQuery = groq`
     _id,
     title,
     description,
-    image,
+    image { asset, alt },
     ctaText,
     ctaLink,
     dismissDurationDays,

--- a/lib/sanity/types.ts
+++ b/lib/sanity/types.ts
@@ -1,6 +1,23 @@
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
 
 /**
+ * Sanity promotional offer document type
+ */
+export interface SanityPromotionalOffer {
+  _id: string;
+  title: string;
+  description: string;
+  image?: SanityImageSource & { alt?: string };
+  ctaText: string;
+  ctaLink: string;
+  isActive: boolean;
+  startDate?: string;
+  endDate?: string;
+  dismissDurationDays: number;
+  displayDelaySeconds: number;
+}
+
+/**
  * Sanity response types
  */
 export interface SanityTreatmentCategory {

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -1,5 +1,6 @@
 import treatment from './treatment';
 import treatmentCategory from './treatmentCategory';
 import siteSettings from './siteSettings';
+import promotionalOffer from './promotionalOffer';
 
-export const schemaTypes = [treatmentCategory, treatment, siteSettings];
+export const schemaTypes = [treatmentCategory, treatment, siteSettings, promotionalOffer];

--- a/sanity/schemas/promotionalOffer.ts
+++ b/sanity/schemas/promotionalOffer.ts
@@ -67,6 +67,15 @@ export default defineType({
       type: 'boolean',
       description: 'Enable or disable this promotional offer',
       initialValue: false,
+      validation: (Rule) =>
+        Rule.custom((isActive, context) => {
+          if (!isActive) return true;
+          const { endDate } = context.document as { endDate?: string };
+          if (endDate && new Date(endDate) < new Date()) {
+            return 'Warning: This offer is active but the end date is in the past';
+          }
+          return true;
+        }),
     }),
     defineField({
       name: 'startDate',

--- a/sanity/schemas/promotionalOffer.ts
+++ b/sanity/schemas/promotionalOffer.ts
@@ -79,6 +79,14 @@ export default defineType({
       title: 'End Date',
       type: 'datetime',
       description: 'Optional: scheduled expiry',
+      validation: (Rule) =>
+        Rule.custom((endDate, context) => {
+          const { startDate } = context.document as { startDate?: string };
+          if (startDate && endDate && new Date(endDate) <= new Date(startDate)) {
+            return 'End date must be after start date';
+          }
+          return true;
+        }),
     }),
     defineField({
       name: 'dismissDurationDays',

--- a/sanity/schemas/promotionalOffer.ts
+++ b/sanity/schemas/promotionalOffer.ts
@@ -32,6 +32,14 @@ export default defineType({
           name: 'alt',
           type: 'string',
           title: 'Alternative Text',
+          validation: (Rule) =>
+            Rule.custom((alt, context) => {
+              const parent = context.parent as { asset?: unknown };
+              if (parent?.asset && !alt) {
+                return 'Alt text is required when an image is provided';
+              }
+              return true;
+            }),
         },
       ],
     }),

--- a/sanity/schemas/promotionalOffer.ts
+++ b/sanity/schemas/promotionalOffer.ts
@@ -1,0 +1,108 @@
+import { defineType, defineField } from 'sanity';
+
+export default defineType({
+  name: 'promotionalOffer',
+  title: 'Promotional Offer',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      description: 'Dialog heading shown to visitors',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+      description: 'Offer body text',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      description: 'Optional promotional image',
+      options: {
+        hotspot: true,
+      },
+      fields: [
+        {
+          name: 'alt',
+          type: 'string',
+          title: 'Alternative Text',
+        },
+      ],
+    }),
+    defineField({
+      name: 'ctaText',
+      title: 'CTA Button Text',
+      type: 'string',
+      description: 'Call-to-action button label (e.g. "Book Now")',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'ctaLink',
+      title: 'CTA Link',
+      type: 'url',
+      description: 'CTA destination URL (supports relative paths like /contact)',
+      validation: (Rule) =>
+        Rule.required().uri({
+          allowRelative: true,
+          scheme: ['http', 'https'],
+        }),
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      description: 'Enable or disable this promotional offer',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'startDate',
+      title: 'Start Date',
+      type: 'datetime',
+      description: 'Optional: scheduled visibility start',
+    }),
+    defineField({
+      name: 'endDate',
+      title: 'End Date',
+      type: 'datetime',
+      description: 'Optional: scheduled expiry',
+    }),
+    defineField({
+      name: 'dismissDurationDays',
+      title: 'Dismiss Duration (Days)',
+      type: 'number',
+      description:
+        'How many days to suppress the dialog after a user dismisses it',
+      initialValue: 7,
+      validation: (Rule) => Rule.required().min(1).max(365),
+    }),
+    defineField({
+      name: 'displayDelaySeconds',
+      title: 'Display Delay (Seconds)',
+      type: 'number',
+      description: 'Delay in seconds before showing the dialog',
+      initialValue: 3,
+      validation: (Rule) => Rule.required().min(0).max(30),
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      isActive: 'isActive',
+      media: 'image',
+    },
+    prepare(selection) {
+      const { title, isActive, media } = selection;
+      return {
+        title,
+        subtitle: isActive ? 'Active' : 'Inactive',
+        media,
+      };
+    },
+  },
+});

--- a/sanity/schemas/promotionalOffer.ts
+++ b/sanity/schemas/promotionalOffer.ts
@@ -34,7 +34,7 @@ export default defineType({
           title: 'Alternative Text',
           validation: (Rule) =>
             Rule.custom((alt, context) => {
-              const parent = context.parent as { asset?: unknown };
+              const parent = context.parent as { asset?: { _ref: string } };
               if (parent?.asset && !alt) {
                 return 'Alt text is required when an image is provided';
               }


### PR DESCRIPTION
## Summary

- Add a dismissable promotional offer dialog managed via Sanity CMS
- Integrate localStorage-based dismissal persistence with configurable cooldown
- Track dialog impressions (`promo_dialog_view`), CTA clicks (`promo_dialog_cta_click`), and dismissals (`promo_dialog_dismiss`) via GA4
- Add Sanity schema, GROQ queries, CMS utilities, and revalidation webhook support
- Include comprehensive tests for the dialog component and CMS layer

## Test plan

- [x] `npm run test` — all 17 PromotionalDialog tests pass (including 4 new GA4 tracking tests)
- [x] `npm run typecheck` — clean
- [ ] Manual: verify dialog appears after configured delay on the site
- [ ] Manual: verify `[GA4] Event tracked:` logs appear in console with `NEXT_PUBLIC_GA4_DEBUG=true`
- [ ] Verify dismissal persists across page reloads and expires after configured duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)