### PR TITLE
feat(theme): Sanctuary redesign foundation — tokens, fonts & base layer (#126)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Cormorant_Garamond, Mulish } from "next/font/google";
 import "./styles/globals.css";
 import { validateEnv } from '@/lib/env';
-import { Playfair_Display, Open_Sans } from 'next/font/google';
 import * as Toast from '@radix-ui/react-toast';
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { Analytics } from "@vercel/analytics/react"
@@ -12,29 +11,20 @@ import { DynamicGoogleAnalytics } from '@/components/Dynamic/DynamicComponents';
 import { GlobalAnalytics } from '@/components/Analytics/GlobalAnalytics';
 import { AnalyticsErrorBoundary } from '@/components/Analytics/AnalyticsErrorBoundary';
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-// Serif font for headings
-const playfair = Playfair_Display({
+// Display serif for headings — Sanctuary redesign
+const cormorant = Cormorant_Garamond({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-playfair',
-  weight: ['400', '500', '600', '700'],
+  variable: '--font-cormorant',
+  weight: ['500', '600'],
+  style: ['normal', 'italic'],
 });
 
-// Sans-serif font for body text
-const openSans = Open_Sans({
+// Body / UI sans — Sanctuary redesign
+const mulish = Mulish({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-open-sans',
+  variable: '--font-mulish',
   weight: ['300', '400', '500', '600', '700'],
 });
 
@@ -88,7 +78,7 @@ export default function RootLayout({
   const googleAdsId = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID;
 
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} ${playfair.variable} ${openSans.variable} antialiased`}>
+    <html lang="en" className={`${cormorant.variable} ${mulish.variable} antialiased`}>
       <body className="font-sans min-h-screen bg-background text-foreground">
         <SpeedInsights />
         <ErrorBoundary

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -1,26 +1,27 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
-
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
+
+  /* Type stack: Mulish (body/UI) + Cormorant Garamond (display serif) */
+  --font-sans: var(--font-mulish);
+  --font-serif: var(--font-cormorant);
+
+  /* Sanctuary palette — exposed as named utilities (bg-sage, text-cocoa, …) */
+  --color-sage: var(--sage);
+  --color-sage-hover: var(--sage-hover);
+  --color-clay: var(--clay);
+  --color-blush: var(--blush);
+  --color-cream: var(--cream);
+  --color-warm-white: var(--warm-white);
+  --color-stone: var(--stone);
+  --color-taupe: var(--taupe);
+  --color-cocoa: var(--cocoa);
+  --color-espresso: var(--espresso);
+
+  /* shadcn semantic tokens */
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -44,53 +45,51 @@
 }
 
 :root {
-  /* Base: Light background, dark foreground */
-  --background: oklch(0.98 0.005 240); /* Very light neutral */
-  --foreground: oklch(0.15 0.03 240); /* Dark neutral */
+  /* ── Sanctuary palette (exact hex from the design spec) ───────────────── */
+  --sage: #8a9a7b; /* primary / CTA */
+  --sage-hover: #6e7e60; /* CTA hover */
+  --clay: #c8a98a; /* accents / rules */
+  --blush: #e8d5c4; /* soft fills */
+  --cream: #f3eee7; /* page background */
+  --warm-white: #faf6f0; /* cards */
+  --stone: #ede6dc; /* alt bands */
+  --taupe: #6b6157; /* secondary text */
+  --cocoa: #4a4038; /* body text */
+  --espresso: #2a2521; /* dark sections */
 
-  /* Card/Popover: Match base background */
-  --card: oklch(0.98 0.005 240);
-  --card-foreground: oklch(0.15 0.03 240);
-  --popover: oklch(0.98 0.005 240);
-  --popover-foreground: oklch(0.15 0.03 240);
+  /* ── shadcn semantic tokens mapped onto the palette ──────────────────── */
+  --background: var(--cream);
+  --foreground: var(--cocoa);
 
-  /* Primary Color - Refined Rose/Mauve (more sophisticated than bright pink) */
-  --primary: oklch(0.65 0.15 13);
-  /* Foreground for Primary: Needs high contrast (light) */
-  --primary-foreground: oklch(0.98 0.005 240); /* Using light base */
+  --card: var(--warm-white);
+  --card-foreground: var(--cocoa);
+  --popover: var(--warm-white);
+  --popover-foreground: var(--cocoa);
 
-  /* Secondary Color */
-  --secondary: oklch(0.87 0.0735 7.09);
-  /* Foreground for Secondary: Needs high contrast (dark) */
-  --secondary-foreground: oklch(0.15 0.03 240); /* Using dark base */
+  --primary: var(--sage);
+  --primary-foreground: var(--warm-white);
 
-  /* Muted: Subtle background/text */
-  --muted: oklch(0.95 0.01 240); /* Slightly darker than background */
-  --muted-foreground: oklch(0.5 0.03 240); /* Mid-tone neutral */
+  --secondary: var(--stone);
+  --secondary-foreground: var(--cocoa);
 
-  /* Accent: Often interactive states, using Secondary color */
-  --accent: oklch(0.87 0.0735 7.09);
-  --accent-foreground: oklch(0.15 0.03 240); /* Dark text */
+  --muted: var(--stone);
+  --muted-foreground: var(--taupe);
 
-  /* Destructive: Red/Orange */
-  --destructive: oklch(0.63 0.237 25.331);
-  --destructive-foreground: oklch(0.98 0.005 240); /* Light text */
+  --accent: var(--blush);
+  --accent-foreground: var(--cocoa);
 
-  /* Border/Input: Subtle lines */
-  --border: oklch(0.92 0.01 240); /* Slightly darker neutral */
-  --input: oklch(0.92 0.01 240);
+  /* Destructive: warm red that sits with the palette */
+  --destructive: #b4443b;
+  --destructive-foreground: var(--warm-white);
 
-  /* Ring: Focus indicator, using Primary */
-  --ring: oklch(0.65 0.15 13);
+  --border: var(--clay);
+  --input: var(--clay);
+  --ring: var(--sage);
 
-  /* Radius */
-  --radius: 0.5rem; /* Default shadcn radius, adjust if needed */
+  /* Base corner radius for cards/controls (pill buttons handled per-component) */
+  --radius: 0.5rem;
 
-  /* Typography */
-  --font-sans: "var(--font-open-sans)", system-ui, -apple-system, sans-serif;
-  --font-serif: "var(--font-playfair)", Georgia, serif;
-
-  /* Font sizes */
+  /* ── Typography scale ────────────────────────────────────────────────── */
   --font-size-xs: 0.75rem; /* 12px */
   --font-size-sm: 0.875rem; /* 14px */
   --font-size-base: 1rem; /* 16px */
@@ -101,20 +100,17 @@
   --font-size-4xl: 2.25rem; /* 36px */
   --font-size-5xl: 3rem; /* 48px */
 
-  /* Line heights */
   --line-height-tight: 1.2;
   --line-height-normal: 1.5;
   --line-height-relaxed: 1.75;
   --line-height-loose: 1.8;
 
-  /* Font weights */
   --font-weight-light: 300;
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
 
-  /* Letter spacing */
   --letter-spacing-tighter: -0.05em;
   --letter-spacing-tight: -0.025em;
   --letter-spacing-normal: 0;
@@ -122,48 +118,6 @@
   --letter-spacing-wide: 0.025em;
   --letter-spacing-wider: 0.05em;
   --letter-spacing-widest: 0.1em;
-}
-
-.dark {
-  /* Base: Dark background, light foreground */
-  --background: oklch(0.15 0.03 240); /* Dark neutral */
-  --foreground: oklch(0.98 0.005 240); /* Light neutral */
-
-  /* Card/Popover: Match dark background */
-  --card: oklch(0.15 0.03 240);
-  --card-foreground: oklch(0.98 0.005 240);
-  --popover: oklch(0.2 0.035 240); /* Slightly lighter than background */
-  --popover-foreground: oklch(0.98 0.005 240);
-
-  /* Primary Color */
-  --primary: oklch(0.7 0.1922 13.3); /* Keeping the same color */
-  /* Foreground for Primary: Needs high contrast (light) */
-  --primary-foreground: oklch(0.98 0.005 240); /* Using light base */
-
-  /* Secondary Color */
-  --secondary: oklch(0.87 0.0735 7.09); /* Keeping the same color */
-  /* Foreground for Secondary: Needs high contrast (dark) */
-  --secondary-foreground: oklch(0.15 0.03 240); /* Using dark base */
-
-  /* Muted: Subtle dark background/lighter text */
-  --muted: oklch(0.25 0.03 240); /* Darker than popover */
-  --muted-foreground: oklch(0.6 0.02 240); /* Lighter mid-tone neutral */
-
-  /* Accent: Using Secondary color, adjust foreground if needed */
-  --accent: oklch(0.87 0.0735 7.09);
-  --accent-foreground: oklch(0.15 0.03 240); /* Dark text */
-  /* Consider a darker accent bg for dark mode? e.g., --accent: oklch(0.3 0.04 240); --accent-foreground: oklch(0.98 0.005 240); */
-
-  /* Destructive: Might need adjustment for dark mode */
-  --destructive: oklch(0.65 0.22 25); /* Slightly adjusted */
-  --destructive-foreground: oklch(0.98 0.005 240); /* Light text */
-
-  /* Border/Input: Subtle lines, slightly lighter than background */
-  --border: oklch(0.25 0.03 240);
-  --input: oklch(0.25 0.03 240);
-
-  /* Ring: Focus indicator, using Primary */
-  --ring: oklch(0.65 0.15 13);
 }
 
 @layer base {
@@ -174,27 +128,27 @@
     @apply bg-background text-foreground;
   }
   h1 {
-    @apply font-serif text-4xl md:text-5xl font-bold leading-tight text-primary mb-6;
+    @apply font-serif text-4xl md:text-5xl font-medium leading-tight text-espresso mb-6;
     letter-spacing: var(--letter-spacing-tighter);
   }
 
   h2 {
-    @apply font-serif text-3xl md:text-4xl font-semibold leading-tight text-primary mb-4;
+    @apply font-serif text-3xl md:text-4xl font-medium leading-tight text-espresso mb-4;
     letter-spacing: var(--letter-spacing-tight);
   }
 
   h3 {
-    @apply font-serif text-2xl md:text-3xl font-medium leading-snug text-primary mb-3;
+    @apply font-serif text-2xl md:text-3xl font-medium leading-snug text-cocoa mb-3;
     letter-spacing: var(--letter-spacing-narrow);
   }
 
   h4 {
-    @apply font-serif text-xl md:text-2xl font-medium leading-snug text-primary mb-2;
+    @apply font-serif text-xl md:text-2xl font-medium leading-snug text-cocoa mb-2;
     letter-spacing: var(--letter-spacing-narrow);
   }
 
   p {
-    @apply font-sans text-base leading-relaxed mb-4 text-foreground;
+    @apply font-sans text-base leading-relaxed mb-4 text-cocoa;
     letter-spacing: var(--letter-spacing-narrow);
   }
 
@@ -203,6 +157,6 @@
   }
 
   blockquote {
-    @apply font-serif text-lg italic border-l-4 border-primary pl-4 py-2 my-6 leading-relaxed;
+    @apply font-serif text-lg font-medium italic border-l-4 border-clay pl-4 py-2 my-6 leading-relaxed text-cocoa;
   }
 }

--- a/components/Contact/ContactForm.tsx
+++ b/components/Contact/ContactForm.tsx
@@ -430,11 +430,11 @@ export default function ContactForm({ initialTreatment, treatments }: ContactFor
       <Toast.Root 
         open={toastState.open} 
         onOpenChange={setToastOpen}
-        className={`p-4 rounded-md shadow-lg ${toastState.variant === 'error' ? 'bg-red-100 dark:bg-red-900' : 'bg-green-100 dark:bg-green-900'}`}
+        className={`p-4 rounded-md shadow-lg ${toastState.variant === 'error' ? 'bg-red-100' : 'bg-green-100'}`}
       >
-        <Toast.Title className={`font-medium ${toastState.variant === 'error' ? 'text-red-800 dark:text-red-100' : 'text-green-800 dark:text-green-100'}`}>{toastState.title}</Toast.Title>
-        <Toast.Description className={`mt-1 text-sm ${toastState.variant === 'error' ? 'text-red-700 dark:text-red-200' : 'text-green-700 dark:text-green-200'}`}>{toastState.description}</Toast.Description>
-        <Toast.Close className="absolute top-1 right-1 p-1 rounded-full text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-700">
+        <Toast.Title className={`font-medium ${toastState.variant === 'error' ? 'text-red-800' : 'text-green-800'}`}>{toastState.title}</Toast.Title>
+        <Toast.Description className={`mt-1 text-sm ${toastState.variant === 'error' ? 'text-red-700' : 'text-green-700'}`}>{toastState.description}</Toast.Description>
+        <Toast.Close className="absolute top-1 right-1 p-1 rounded-full text-gray-500 hover:bg-gray-200">
            <Cross2Icon className="h-4 w-4" />
         </Toast.Close>
       </Toast.Root>

--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -82,7 +82,7 @@ export default function Footer() {
                     alt=""
                     width={24}
                     height={24}
-                    className="filter dark:invert text-primary group-hover:scale-110 transition-transform duration-200"
+                    className="text-primary group-hover:scale-110 transition-transform duration-200"
                   />
                 </div>
                 <span className="text-sm font-medium text-muted-foreground/85 group-hover:text-primary transition-colors duration-200">Facebook</span>
@@ -101,7 +101,7 @@ export default function Footer() {
                     alt=""
                     width={24}
                     height={24}
-                    className="filter dark:invert text-primary group-hover:scale-110 transition-transform duration-200"
+                    className="text-primary group-hover:scale-110 transition-transform duration-200"
                   />
                 </div>
                 <span className="text-sm font-medium text-muted-foreground/85 group-hover:text-primary transition-colors duration-200">Instagram</span>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,20 +5,20 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-out disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive active:scale-95",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-out disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive active:scale-95",
   {
     variants: {
       variant: {
         default:
           "bg-primary text-primary-foreground shadow-md hover:shadow-lg hover:bg-primary/85 hover:-translate-y-0.5 active:shadow-sm active:translate-y-0",
         destructive:
-          "bg-destructive text-white shadow-md hover:shadow-lg hover:bg-destructive/85 hover:-translate-y-0.5 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 active:shadow-sm active:translate-y-0",
+          "bg-destructive text-white shadow-md hover:shadow-lg hover:bg-destructive/85 hover:-translate-y-0.5 focus-visible:ring-destructive/20 active:shadow-sm active:translate-y-0",
         outline:
-          "border-2 border-border bg-transparent text-foreground shadow-sm hover:shadow-md hover:bg-accent/50 hover:text-accent-foreground hover:border-accent hover:-translate-y-0.5 dark:border-input dark:hover:bg-accent/30 active:shadow-none active:translate-y-0",
+          "border-2 border-border bg-transparent text-foreground shadow-sm hover:shadow-md hover:bg-accent/50 hover:text-accent-foreground hover:border-accent hover:-translate-y-0.5 active:shadow-none active:translate-y-0",
         secondary:
           "bg-secondary text-secondary-foreground shadow-md hover:shadow-lg hover:bg-secondary/70 hover:-translate-y-0.5 active:shadow-sm active:translate-y-0",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground hover:shadow-sm hover:-translate-y-0.5 dark:hover:bg-accent/50 active:shadow-none active:translate-y-0",
+          "hover:bg-accent hover:text-accent-foreground hover:shadow-sm hover:-translate-y-0.5 active:shadow-none active:translate-y-0",
         link: "text-primary underline-offset-4 hover:underline hover:text-primary/80 transition-colors",
 
       },

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,9 +8,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground/70 selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-10 w-full min-w-0 rounded-md border-2 border-b-4 bg-transparent px-3 py-2 text-base shadow-sm transition-all duration-200 ease-out outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted/30 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground/70 selection:bg-primary selection:text-primary-foreground border-input flex h-10 w-full min-w-0 rounded-md border-2 border-b-4 bg-transparent px-3 py-2 text-base shadow-sm transition-all duration-200 ease-out outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted/30 md:text-sm",
         "focus-visible:border-ring focus-visible:border-b-4 focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:shadow-md",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:focus-visible:ring-destructive/30 dark:aria-invalid:ring-destructive/40",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:focus-visible:ring-destructive/30",
         className
       )}
       {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,9 +7,9 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground/70 dark:bg-input/30 flex field-sizing-content min-h-24 w-full rounded-md border-2 border-b-4 bg-transparent px-3 py-2 text-base shadow-sm transition-all duration-200 ease-out outline-none disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted/30 md:text-sm",
+        "border-input placeholder:text-muted-foreground/70 flex field-sizing-content min-h-24 w-full rounded-md border-2 border-b-4 bg-transparent px-3 py-2 text-base shadow-sm transition-all duration-200 ease-out outline-none disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted/30 md:text-sm",
         "focus-visible:border-ring focus-visible:border-b-4 focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:shadow-md",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:focus-visible:ring-destructive/30 dark:aria-invalid:ring-destructive/40",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:focus-visible:ring-destructive/30",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Establishes the shared visual substrate for the **Sanctuary** redesign so every later page slice inherits it (prefactor: make the change easy, then make the easy change). Closes #126.

- **Tokens** — Replaced the shadcn rose/mauve OKLCH set in `globals.css` with the Sanctuary hex palette; exposed the palette as named utilities (`bg-sage`, `text-cocoa`, `border-clay`, …) via `@theme inline` so later slices can use them directly.
- **Dark mode dropped** — Removed the `.dark` block, the `@custom-variant dark` line, and every residual `dark:` utility (button, checkbox, input, select, textarea, ContactForm toasts, Footer icons). Site is light-only; no `prefers-color-scheme` fallback can fire.
- **Fonts** — Self-hosted via `next/font`: **Cormorant Garamond** (display serif) + **Mulish** (body/UI) wired to CSS variables. Removed Geist, Geist_Mono, Playfair, Open Sans.
- **Base layer** — `h1`–`h4` recolored to Espresso/Cocoa, body to Cocoa, secondary text to Taupe; Sage reserved for accents.

## Acceptance criteria (#126)

- [x] `globals.css` token set replaced with Sanctuary palette; old OKLCH removed
- [x] `.dark` block and dark-mode logic removed; no dark variant remains
- [x] Cormorant Garamond + Mulish loaded via `next/font`, wired to CSS vars; old fonts removed
- [x] Base `h1`–`h4` in Cocoa/Espresso, body in Cocoa, secondary in Taupe
- [x] `npm run typecheck`, `npm run lint`, `npm run build` all pass (92 tests pass)

## Notes / deferred

- Pill (999px) buttons and the full 72px display type scale are **description-level** items owned by later slices (#128 layout shell onward), not this foundation issue's acceptance criteria.
- Page-level headings still using `text-primary` are untouched — the rollout is explicitly incremental, page by page.
- Cormorant loaded at weights `['500','600']` (not 500-only) so not-yet-reskinned pages using `font-semibold` don't render synthetic bold during the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)