### PR TITLE
feat(treatments): lazy per-category fetch layer for accordion menu (#127)

### DIFF
--- a/__tests__/lib/cms/treatments.test.ts
+++ b/__tests__/lib/cms/treatments.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getTreatmentMenuByCategory } from '@/lib/cms/treatments';
+import { sanityClient } from '@/lib/sanity/client';
+import { treatmentsMenuByCategoryQuery } from '@/lib/sanity/queries';
+import type { SanityTreatmentMenuItem } from '@/lib/sanity/types';
+
+vi.mock('@/lib/sanity/client', () => ({
+  sanityClient: {
+    fetch: vi.fn(),
+  },
+}));
+
+// sanityClient.fetch is heavily overloaded; treat the mock as a simple
+// async function so resolved/rejected values type-check cleanly.
+const mockedFetch = sanityClient.fetch as unknown as ReturnType<typeof vi.fn>;
+
+describe('getTreatmentMenuByCategory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('returns accordion-row-shaped items for a category (happy path)', async () => {
+    const rows: SanityTreatmentMenuItem[] = [
+      {
+        _id: 'treatment-1',
+        title: 'Swedish Full Body Massage',
+        slug: 'swedish-full-body-massage',
+        description: 'Relax and unwind with a classic full-body Swedish massage.',
+        duration: '60 mins',
+        price: '£40',
+        categorySlug: 'massages',
+      },
+    ];
+    mockedFetch.mockResolvedValueOnce(rows);
+
+    const result = await getTreatmentMenuByCategory('massages');
+
+    // Uses the parameterized GROQ query with the category slug (server-side filter).
+    expect(mockedFetch).toHaveBeenCalledWith(treatmentsMenuByCategoryQuery, {
+      categorySlug: 'massages',
+    });
+    expect(result).toEqual([
+      {
+        id: 'treatment-1',
+        name: 'Swedish Full Body Massage',
+        slug: 'swedish-full-body-massage',
+        shortDescription:
+          'Relax and unwind with a classic full-body Swedish massage.',
+        durationLabel: '60 mins',
+        price: '£40',
+        href: '/treatments/massages/swedish-full-body-massage',
+      },
+    ]);
+  });
+
+  it('returns an empty list for an unknown or empty category', async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+
+    const result = await getTreatmentMenuByCategory('does-not-exist');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list (no crash) when the query throws', async () => {
+    mockedFetch.mockRejectedValueOnce(new Error('Sanity unavailable'));
+
+    const result = await getTreatmentMenuByCategory('massages');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/app/treatments/actions.ts
+++ b/app/treatments/actions.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { getTreatmentMenuByCategory } from '@/lib/cms/treatments';
+import type { TreatmentMenuItem } from '@/lib/data/treatments';
+
+/**
+ * Server action backing the lazy-loaded `/treatments` accordion.
+ *
+ * Called from the client when a category panel expands; returns just that
+ * category's treatments in accordion-row shape. An empty/blank slug short-circuits
+ * to `[]` so the UI never issues a pointless query or crashes.
+ */
+export async function fetchCategoryTreatmentMenu(
+  categorySlug: string
+): Promise<TreatmentMenuItem[]> {
+  if (!categorySlug?.trim()) {
+    return [];
+  }
+
+  return getTreatmentMenuByCategory(categorySlug);
+}

--- a/lib/cms/treatments.ts
+++ b/lib/cms/treatments.ts
@@ -4,6 +4,7 @@ import {
   allTreatmentsQuery,
   treatmentBySlugQuery,
   treatmentsByCategoryQuery,
+  treatmentsMenuByCategoryQuery,
   allTreatmentSlugsQuery,
   categoryBySlugQuery,
 } from '@/lib/sanity/queries';
@@ -11,11 +12,13 @@ import { getImageUrl } from '@/lib/sanity/image';
 import {
   SanityTreatment,
   SanityTreatmentCategory,
+  SanityTreatmentMenuItem,
 } from '@/lib/sanity/types';
 import {
   Treatment,
   TreatmentCategory,
   TreatmentCategorySlug,
+  TreatmentMenuItem,
 } from '@/lib/data/treatments';
 
 /**
@@ -133,6 +136,50 @@ export async function getTreatmentsByCategory(
     return treatments.map(transformTreatment);
   } catch (error) {
     console.error('Error fetching treatments by category from Sanity:', error);
+    return [];
+  }
+}
+
+/**
+ * Transform a lean Sanity menu row into the accordion-row shape
+ */
+function transformTreatmentMenuItem(
+  row: SanityTreatmentMenuItem
+): TreatmentMenuItem {
+  return {
+    id: row._id,
+    name: row.title,
+    slug: row.slug,
+    shortDescription: row.description,
+    durationLabel: row.duration,
+    price: row.price,
+    href: `/treatments/${row.categorySlug}/${row.slug}`,
+  };
+}
+
+/**
+ * Fetch a lean, accordion-row-shaped list of treatments for a single category.
+ *
+ * Backs the lazy-loaded `/treatments` accordion: category headers render
+ * immediately and each panel resolves its rows on expand. Uses the
+ * parameterized `treatmentsMenuByCategoryQuery` (server-side GROQ filtering by
+ * slug — never fetch-all-then-filter) and returns `[]` for unknown/empty
+ * categories or on error, so the UI never crashes.
+ */
+export async function getTreatmentMenuByCategory(
+  categorySlug: string
+): Promise<TreatmentMenuItem[]> {
+  try {
+    const rows = await sanityClient.fetch<SanityTreatmentMenuItem[]>(
+      treatmentsMenuByCategoryQuery,
+      { categorySlug }
+    );
+    return (rows ?? []).map(transformTreatmentMenuItem);
+  } catch (error) {
+    console.error(
+      'Error fetching treatment menu by category from Sanity:',
+      error
+    );
     return [];
   }
 }

--- a/lib/data/treatments.ts
+++ b/lib/data/treatments.ts
@@ -26,6 +26,21 @@ export interface Treatment {
   }
   
   /**
+   * Lightweight, accordion-row-shaped treatment used by the lazy-loaded
+   * `/treatments` menu. Derived from {@link Treatment} but carries only the
+   * fields a menu row renders, plus a ready-to-use detail-page `href`.
+   */
+  export interface TreatmentMenuItem {
+    id: string;
+    name: string;
+    slug: string;
+    shortDescription: string;
+    durationLabel: string;
+    price: string;
+    href: string;
+  }
+
+  /**
    * Represents the different categories of treatments.
    */
   export interface TreatmentCategory {

--- a/lib/sanity/queries.ts
+++ b/lib/sanity/queries.ts
@@ -98,6 +98,24 @@ export const treatmentsByCategoryQuery = groq`
 `;
 
 /**
+ * GROQ query to fetch a lean, accordion-row-shaped list of treatments for a
+ * single category. Parameterized by `$categorySlug` so filtering happens
+ * server-side (no fetch-all-then-filter), and projects only the fields the
+ * lazy-loaded accordion menu renders (no image asset).
+ */
+export const treatmentsMenuByCategoryQuery = groq`
+  *[_type == "treatment" && category->slug.current == $categorySlug] {
+    _id,
+    title,
+    "slug": slug.current,
+    description,
+    duration,
+    price,
+    "categorySlug": category->slug.current
+  }
+`;
+
+/**
  * GROQ query to fetch all treatment slugs for static generation
  */
 export const allTreatmentSlugsQuery = groq`

--- a/lib/sanity/types.ts
+++ b/lib/sanity/types.ts
@@ -14,6 +14,20 @@ export interface SanityTreatmentCategory {
   displayOrder?: number;
 }
 
+/**
+ * Lean Sanity response for the lazy-loaded treatments accordion menu.
+ * Only the fields an accordion row needs — no image asset (rows are text-only).
+ */
+export interface SanityTreatmentMenuItem {
+  _id: string;
+  title: string;
+  slug: string;
+  description: string;
+  duration: string;
+  price: string;
+  categorySlug: string;
+}
+
 export interface SanityTreatment {
   _id: string;
   title: string;


### PR DESCRIPTION
## Summary

Implements **#127** — a pure data-plumbing slice (no visual work) for the upcoming `/treatments` accordion. Each category's treatments load on demand when its panel expands, instead of loading every treatment up front, preserving the documented parameterized-query efficiency.

## Changes

- **`treatmentsMenuByCategoryQuery`** (`lib/sanity/queries.ts`) — lean parameterized GROQ that filters server-side by `$categorySlug` and projects only accordion-row fields (no image asset). No fetch-all-then-filter; ordering matches the existing category query for menu/detail consistency.
- **`getTreatmentMenuByCategory()`** (`lib/cms/treatments.ts`) — returns `TreatmentMenuItem[]` (name, slug, short description, duration label, price, detail `href`); returns `[]` for unknown/empty categories or on error.
- **`fetchCategoryTreatmentMenu()`** (`app/treatments/actions.ts`) — `'use server'` action the client accordion calls on panel expand.
- New types: `SanityTreatmentMenuItem` (lean response) and `TreatmentMenuItem` (app-facing row shape).
- **Unit tests** (`__tests__/lib/cms/treatments.test.ts`) — happy path, empty/unknown category, and query error.

## Acceptance criteria

- [x] Server action returns treatments for a single category slug via the parameterized GROQ query (no client-side filtering of a full list)
- [x] Response shape includes name, slug, duration label, price, short description
- [x] Unknown/empty category handled gracefully (empty list, no crash)
- [x] Unit test covers the fetch layer (happy path + empty/unknown)
- [x] `npm run typecheck`, `npm run lint`, and `npm run test` (95 passing) all green

## Notes

- Added a lean dedicated query rather than reusing `getTreatmentsByCategory()` verbatim — that function builds Sanity CDN image URLs the text-only menu never renders. The binding constraint (server-side filtering, no fetch-all-then-filter) is preserved.
- Unblocks **#131** (treatments accordion UI).

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)