### PR TITLE
feat(home): Sanctuary homepage sections — hero, marquee, intro & services

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,6 @@ import {
   ContactInfo as ContactInfoType
 } from '@/lib/jsonLsUtils';
 import { config } from '@/lib/config';
-import { getCategories } from '@/lib/cms/treatments';
 
 export async function generateMetadata(): Promise<Metadata> {
   const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || '';
@@ -75,8 +74,6 @@ async function HomePage() {
   // Business schema without aggregateRating (will be added when real review data is integrated)
   const businessJsonLd = generateHealthAndBeautyBusinessJsonLd(contactInfo as ContactInfoType);
   const faqJsonLd = generateFAQJsonLd(homepageFAQs);
-  const categories = await getCategories();
-
   // Combine all JSON-LD schemas (server-generated from trusted utility functions)
   const jsonLdContent = JSON.stringify([webSiteJsonLd, businessJsonLd, faqJsonLd]);
 
@@ -98,7 +95,7 @@ async function HomePage() {
       <IntroductionSection />
 
       {/* Numbered treatment category cards */}
-      <ServicesSection categories={categories} />
+      <ServicesSection />
 
       {/* Client testimonials */}
       <DynamicTestimonials />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import type { Metadata } from 'next';
 import { MainLayout } from '@/components/Layout/MainLayout';
-import {
-  DynamicTestimonials,
-  DynamicExperienceSection,
-  DynamicServicesSection
-} from '@/components/Dynamic/DynamicComponents';
+import { DynamicTestimonials } from '@/components/Dynamic/DynamicComponents';
 
 import MainHeader from '@/components/Sections/MainHeader';
+import MarqueeStrip from '@/components/Sections/MarqueeStrip';
+import IntroductionSection from '@/components/Sections/Introduction';
 import ServicesSection from '@/components/Sections/Services';
 import Script from 'next/script';
 import { contactInfo } from '@/lib/data/contactInfo';
@@ -18,8 +16,6 @@ import {
   ContactInfo as ContactInfoType
 } from '@/lib/jsonLsUtils';
 import { config } from '@/lib/config';
-import LocationAndBookingSection from '@/components/Sections/LocationAndBooking';
-import IntroductionSection from '@/components/Sections/Introduction';
 import { getCategories } from '@/lib/cms/treatments';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -91,16 +87,20 @@ async function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: jsonLdContent }}
       />
+
+      {/* Hero — two-column Sanctuary layout */}
       <MainHeader />
 
+      {/* Scrolling service categories marquee */}
+      <MarqueeStrip />
+
+      {/* Welcome / Meet Hayley */}
       <IntroductionSection />
-      <ServicesSection categories={categories} showAllButton={false} />
 
+      {/* Numbered treatment category cards */}
+      <ServicesSection categories={categories} />
 
-      <DynamicExperienceSection />
-
-      <LocationAndBookingSection />
-
+      {/* Client testimonials */}
       <DynamicTestimonials />
     </MainLayout>
   );

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -160,3 +160,19 @@
     @apply font-serif text-lg font-medium italic border-l-4 border-clay pl-4 py-2 my-6 leading-relaxed text-cocoa;
   }
 }
+
+@keyframes marquee-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.animate-marquee {
+  animation: marquee-scroll 35s linear infinite;
+  will-change: transform;
+  display: flex;
+  width: max-content;
+}

--- a/components/Sections/Introduction.tsx
+++ b/components/Sections/Introduction.tsx
@@ -1,52 +1,75 @@
-'use client';
+import Image from 'next/image';
+import Link from 'next/link';
 
-import { useId } from 'react';
-import { cn } from '@/lib/utils';
-
-type IntroductionSectionProps = {
-  id?: string;
-  className?: string;
-};
-
-const PARAGRAPH_CLASS = "font-sans text-lg text-muted-foreground leading-relaxed";
-
-const CONTENT = {
-  heading: "Welcome to Heavenly Treatments",
-  paragraphs: [
-    { id: "experience", text: "I'm Hayley, a qualified Spa Therapist with years of experience working in 5-star establishments." },
-    { id: "treatment-room", text: "I'm bringing that experience to my home treatment room for you to enjoy." },
-    { id: "passion", text: "I have always had a passion for wellness and skincare and have carefully curated a treatment menu of all my favourite treatments." }
-  ]
-} as const satisfies {
-  heading: string;
-  paragraphs: readonly { id: string; text: string }[];
-};
-
-export default function IntroductionSection({ id, className }: IntroductionSectionProps) {
-  const reactId = useId();
-  const sectionId = id ?? `introduction-${reactId}`;
-  const headingId = `${sectionId}-heading`;
-  
+/**
+ * IntroductionSection — Meet Hayley / Welcome block (Issue #129)
+ *
+ * Two-column layout on tablet/desktop: arched owner photo left,
+ * bio copy right. Stacks single-column on mobile with image on top.
+ * Server component — no interactivity required.
+ */
+export default function IntroductionSection() {
   return (
     <section
-      id={sectionId}
-      aria-labelledby={headingId}
-      className={cn("py-16 md:py-24 bg-background", className)}
+      aria-labelledby="about-heading"
+      className="py-16 md:py-24 bg-cream"
     >
-      <div className="container mx-auto px-4">
-        <div className="max-w-3xl mx-auto text-center space-y-8">
-          <header>
-            <h2 id={headingId} className="font-serif text-3xl md:text-4xl font-semibold text-primary">
-              {CONTENT.heading}
-            </h2>
-          </header>
-          <div className="space-y-6">
-            {CONTENT.paragraphs.map((paragraph) => (
-              <p key={paragraph.id} className={PARAGRAPH_CLASS}>
-                {paragraph.text}
-              </p>
-            ))}
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col md:flex-row items-center gap-12">
+
+          {/* ── Left column: framed image ────────────────────────────── */}
+          <div className="flex-1 w-full max-w-[480px] mx-auto md:mx-0">
+            {/* Arched image with overlaid badge */}
+            <div className="relative rounded-t-[200px] overflow-hidden aspect-[3/4]">
+              <Image
+                src="/images/about/owner-of-heavenly-treatments.jpg"
+                alt="Hayley, owner and lead therapist at Heavenly Treatments in Kelso"
+                fill
+                sizes="(max-width: 768px) 100vw, 50vw"
+                style={{ objectFit: 'cover' }}
+              />
+              {/* Badge — overlaid inside the image container */}
+              <div className="absolute bottom-6 left-4 z-10">
+                <span className="bg-sage text-warm-white rounded-full px-5 py-2 font-sans text-xs font-semibold tracking-widest uppercase">
+                  ✦ 5★ Spa Trained
+                </span>
+              </div>
+            </div>
           </div>
+
+          {/* ── Right column: bio text ───────────────────────────────── */}
+          <div className="flex-1 flex flex-col justify-center gap-6 text-center md:text-left">
+            <span className="font-sans text-[11px] uppercase tracking-widest text-taupe">
+              A little about me
+            </span>
+
+            <h2
+              id="about-heading"
+              className="font-serif text-espresso mb-0"
+            >
+              Meet Hayley, your personal spa therapist
+            </h2>
+
+            <div className="flex flex-col gap-4">
+              <p className="font-sans text-base text-cocoa leading-relaxed mb-0">
+                I&apos;m a qualified spa therapist with years of experience
+                working in 5-star establishments — now bringing that same level
+                of care and expertise to my home treatment room in Kelso.
+              </p>
+              <p className="font-sans text-base text-cocoa leading-relaxed mb-0">
+                I&apos;ve curated a menu of treatments I love, using organic and
+                vegan-friendly products to nurture your mind, body, and soul.
+              </p>
+            </div>
+
+            <Link
+              href="/about"
+              className="font-sans text-sm text-sage hover:underline w-fit mx-auto md:mx-0"
+            >
+              More about me →
+            </Link>
+          </div>
+
         </div>
       </div>
     </section>

--- a/components/Sections/Introduction.tsx
+++ b/components/Sections/Introduction.tsx
@@ -1,75 +1,73 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-/**
- * IntroductionSection — Meet Hayley / Welcome block (Issue #129)
- *
- * Two-column layout on tablet/desktop: arched owner photo left,
- * bio copy right. Stacks single-column on mobile with image on top.
- * Server component — no interactivity required.
- */
 export default function IntroductionSection() {
   return (
     <section
       aria-labelledby="about-heading"
-      className="py-16 md:py-24 bg-cream"
+      className="hidden lg:block py-20 xl:py-28 bg-cream"
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col md:flex-row items-center gap-12">
+        <div className="flex items-center gap-16 xl:gap-20">
 
-          {/* ── Left column: framed image ────────────────────────────── */}
-          <div className="flex-1 w-full max-w-[480px] mx-auto md:mx-0">
-            {/* Arched image with overlaid badge */}
-            <div className="relative rounded-t-[200px] overflow-hidden aspect-[3/4]">
+          {/* Left: portrait image with overlapping badge */}
+          <div className="flex-1 relative max-w-[420px]">
+            <div className="relative rounded-2xl overflow-hidden aspect-[3/4]">
               <Image
                 src="/images/about/owner-of-heavenly-treatments.jpg"
                 alt="Hayley, owner and lead therapist at Heavenly Treatments in Kelso"
                 fill
-                sizes="(max-width: 768px) 100vw, 50vw"
-                style={{ objectFit: 'cover' }}
+                sizes="45vw"
+                className="object-cover"
               />
-              {/* Badge — overlaid inside the image container */}
-              <div className="absolute bottom-6 left-4 z-10">
-                <span className="bg-sage text-warm-white rounded-full px-5 py-2 font-sans text-xs font-semibold tracking-widest uppercase">
-                  ✦ 5★ Spa Trained
-                </span>
-              </div>
+            </div>
+            {/* Badge overlaps the bottom-right corner of the image */}
+            <div className="absolute bottom-[-16px] right-[-16px] bg-sage rounded-2xl px-5 py-4 text-center min-w-[110px]">
+              <p className="font-serif text-warm-white text-2xl leading-none mb-0">5★</p>
+              <p className="font-sans text-warm-white text-[10px] uppercase tracking-widest mt-1 mb-0">
+                Spa Trained
+              </p>
             </div>
           </div>
 
-          {/* ── Right column: bio text ───────────────────────────────── */}
-          <div className="flex-1 flex flex-col justify-center gap-6 text-center md:text-left">
-            <span className="font-sans text-[11px] uppercase tracking-widest text-taupe">
-              A little about me
-            </span>
+          {/* Right: bio copy */}
+          <div className="flex-1 flex flex-col gap-6">
+
+            {/* Eyebrow */}
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-px bg-clay" />
+              <span className="font-sans text-[11px] uppercase tracking-[0.24em] text-taupe">
+                Welcome
+              </span>
+            </div>
 
             <h2
               id="about-heading"
-              className="font-serif text-espresso mb-0"
+              className="font-serif text-4xl xl:text-[52px] text-espresso leading-[1.1] mb-0"
             >
-              Meet Hayley, your personal spa therapist
+              I&apos;m Hayley — a qualified spa therapist, bringing five-star care home.
             </h2>
 
             <div className="flex flex-col gap-4">
               <p className="font-sans text-base text-cocoa leading-relaxed mb-0">
-                I&apos;m a qualified spa therapist with years of experience
-                working in 5-star establishments — now bringing that same level
-                of care and expertise to my home treatment room in Kelso.
+                After years working in five-star establishments, I&apos;ve brought that experience
+                to my own treatment room. I&apos;ve always had a passion for wellness and skincare,
+                and have carefully curated a menu of all my favourite treatments.
               </p>
               <p className="font-sans text-base text-cocoa leading-relaxed mb-0">
-                I&apos;ve curated a menu of treatments I love, using organic and
-                vegan-friendly products to nurture your mind, body, and soul.
+                Each appointment begins with a brief consultation, so every treatment is
+                aligned with exactly what you need.
               </p>
             </div>
 
             <Link
               href="/about"
-              className="font-sans text-sm text-sage hover:underline w-fit mx-auto md:mx-0"
+              className="font-sans text-sm font-semibold text-espresso underline underline-offset-4 hover:opacity-70 transition-opacity w-fit"
             >
               More about me →
             </Link>
-          </div>
 
+          </div>
         </div>
       </div>
     </section>

--- a/components/Sections/MainHeader.tsx
+++ b/components/Sections/MainHeader.tsx
@@ -90,7 +90,7 @@ const MainHeader: React.FC = () => {
               aria-hidden="true"
             />
 
-            <div className="relative w-full max-w-[560px] mx-auto">
+            <div className="relative w-full max-w-[440px] mx-auto">
               <div className="relative w-full aspect-square md:aspect-[4/5] rounded-t-full overflow-hidden border border-clay/20">
                 <Image
                   src="/images/mainPage/young-woman-having-face-massage-relaxing-spa-salon.jpg"

--- a/components/Sections/MainHeader.tsx
+++ b/components/Sections/MainHeader.tsx
@@ -5,28 +5,39 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { BookingButton } from '@/components/BookingButton';
 
-/**
- * MainHeader — Sanctuary-themed hero section (Issue #129)
- *
- * Two-column layout on tablet/desktop (content left, arched image right).
- * Stacks to single column on mobile with image on top.
- */
+const TrustRowContent: React.FC = () => (
+  <>
+    <div className="flex flex-col items-start gap-1">
+      <span className="text-xl text-sage leading-none" aria-label="Five star rating">★★★★★</span>
+      <span className="font-sans text-xs text-taupe">Loved by local clients</span>
+    </div>
+    <span className="w-px h-8 bg-clay/40" aria-hidden="true" />
+    <div className="flex flex-col gap-0.5">
+      <span className="font-sans text-xs text-taupe">Organic &amp; natural products</span>
+      <span className="font-sans text-xs text-taupe">100% vegan &amp; cruelty-free</span>
+    </div>
+  </>
+);
+
 const MainHeader: React.FC = () => {
   return (
     <section
       aria-labelledby="hero-heading"
-      className="py-16 md:py-24 bg-cream"
+      className="pt-8 pb-16 md:pt-12 md:pb-20 lg:py-24 bg-cream overflow-hidden"
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col-reverse md:flex-row items-center gap-12">
+        {/*
+          Mobile:  flex-col  → content first, image second, trust row third
+          Desktop: flex-row  → left column (content+trust) | right column (image)
+        */}
+        <div className="flex flex-col md:flex-row md:items-center gap-10 md:gap-16">
 
           {/* ── Left column: content ─────────────────────────────────── */}
-          <div className="flex-1 flex flex-col justify-center gap-6 text-center md:text-left">
+          <div className="flex-1 flex flex-col gap-6 text-left">
 
             {/* Eyebrow */}
-            <div className="flex items-center gap-3 justify-center md:justify-start" aria-hidden="true">
-              <div className="w-10 h-px bg-clay" />
-              <span className="w-1.5 h-1.5 rounded-full bg-clay block" />
+            <div className="flex items-center gap-3" aria-hidden="true">
+              <div className="w-8 h-px bg-clay" />
               <span className="font-sans text-[11px] uppercase tracking-[0.24em] text-taupe">
                 Kelso · Scottish Borders
               </span>
@@ -35,65 +46,67 @@ const MainHeader: React.FC = () => {
             {/* H1 */}
             <h1
               id="hero-heading"
-              className="font-serif text-4xl md:text-[40px] lg:text-[56px] font-medium leading-tight text-espresso mb-0"
+              className="font-serif text-4xl sm:text-5xl lg:text-[68px] xl:text-[76px] font-normal leading-[1.1] text-espresso mb-0"
             >
-              Your sanctuary for{' '}
-              <em className="italic text-sage">heavenly</em>
-              {' '}treatments
+              Revitalise your mind, body &amp;{' '}
+              <em className="italic text-sage">soul.</em>
             </h1>
 
             {/* Lead paragraph */}
-            <p className="font-sans text-[17px] text-taupe max-w-[400px] mx-auto md:mx-0 leading-relaxed mb-0">
-              Bespoke spa therapies in the heart of Kelso, Scottish Borders.
-              Organic, vegan-friendly and deeply relaxing.
+            <p className="font-sans text-base md:text-[17px] text-taupe max-w-[520px] leading-relaxed mb-0">
+              A five-star cottage spa experience, hidden in the Scottish
+              countryside. Massage, facials &amp; reflexology —
+              thoughtfully crafted by Hayley.
             </p>
 
             {/* CTA row */}
-            <div className="flex flex-wrap items-center gap-4 justify-center md:justify-start">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
               <BookingButton
                 context="hero"
-                className="rounded-full px-8 py-3 h-auto font-sans font-semibold text-sm hover:bg-sage-hover transition-colors"
+                className="rounded-full px-8 py-3 h-auto font-sans font-semibold text-sm transition-colors w-full sm:w-auto"
               >
                 Book a treatment
               </BookingButton>
               <Link
                 href="/treatments"
-                className="font-sans text-sm text-cocoa hover:underline"
+                className="hidden md:inline-block font-sans text-sm text-cocoa underline underline-offset-2 hover:text-espresso transition-colors"
               >
                 Explore the menu →
               </Link>
             </div>
 
-            {/* Trust row */}
-            <div className="flex items-center gap-3 justify-center md:justify-start mt-2">
-              <span className="text-sm text-clay" aria-label="Five star rating">★★★★★</span>
-              <span className="w-px h-4 bg-clay" aria-hidden="true" />
-              <span className="font-sans text-xs text-taupe">
-                Organic &amp; vegan friendly
-              </span>
+            {/* Trust row — tablet/desktop only (mobile renders after image below) */}
+            <div className="hidden md:flex flex-wrap items-center gap-5">
+              <TrustRowContent />
             </div>
           </div>
 
           {/* ── Right column: arched image ───────────────────────────── */}
-          <div className="flex-1 flex justify-center w-full">
-            <div className="relative w-full max-w-[420px] mx-auto">
-              {/* Clay accent ring — desktop/tablet only */}
-              <div
-                className="absolute inset-0 rounded-t-[260px] border-2 border-clay translate-x-3 translate-y-3 hidden md:block"
-                aria-hidden="true"
-              />
-              {/* Arched image */}
-              <div className="relative z-10 w-full aspect-[3/4] rounded-t-[260px] overflow-hidden max-h-[360px] md:max-h-none">
+          <div className="flex-1 flex justify-center relative">
+
+            {/* Decorative circle — tablet/desktop only */}
+            <div
+              className="absolute top-[-20px] right-[-10px] w-[150px] h-[150px] lg:w-[190px] lg:h-[190px] rounded-full border border-clay/25 hidden md:block"
+              aria-hidden="true"
+            />
+
+            <div className="relative w-full max-w-[560px] mx-auto">
+              <div className="relative w-full aspect-square md:aspect-[4/5] rounded-t-full overflow-hidden border border-clay/20">
                 <Image
                   src="/images/mainPage/young-woman-having-face-massage-relaxing-spa-salon.jpg"
                   alt="Young woman receiving a relaxing face massage at Heavenly Treatments spa"
                   fill
-                  sizes="(max-width: 768px) 100vw, 50vw"
+                  sizes="(max-width: 768px) 90vw, 45vw"
                   priority
-                  style={{ objectFit: 'cover' }}
+                  className="object-cover"
                 />
               </div>
             </div>
+          </div>
+
+          {/* Trust row — mobile only, 3rd flex item so it renders after image */}
+          <div className="md:hidden flex flex-wrap items-center gap-5">
+            <TrustRowContent />
           </div>
 
         </div>

--- a/components/Sections/MainHeader.tsx
+++ b/components/Sections/MainHeader.tsx
@@ -1,123 +1,105 @@
 'use client';
 
-import React, { useId } from 'react';
-import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
-import OptimizedImage from '@/components/OptimizedImage';
+import React from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
-
-// Component configuration constants
-const HERO_CONFIG = {
-  heights: {
-    mobile: 'h-[60svh]',
-    desktop: 'md:h-[70svh]'
-  },
-  image: {
-    src: 'young-woman-having-face-massage-relaxing-spa-salon',
-    alt: 'Young woman having face massage relaxing in a spa salon',
-    decorative: true,
-    fallback: '/images/mainPage/young-woman-having-face-massage-relaxing-spa-salon.jpg'
-  },
-  content: {
-    title: 'Professional Massage, Facials, Reflexology and Beauty Treatments in Kelso',
-    subtitle: 'Revitalize Your Mind, Body, and Soul at Heavenly Treatments – Kelso\'s Hidden Gem for Relaxation and Wellness.',
-    ctaText: 'Explore Treatments',
-    ctaLink: '/treatments'
-  }
-} as const;
-
-// CSS class combinations for better readability
-const styles = {
-  hero: `relative ${HERO_CONFIG.heights.mobile} ${HERO_CONFIG.heights.desktop} w-full 
-         flex items-center justify-center text-center overflow-hidden`,
-  
-  imageContainer: 'absolute inset-0 z-0',
-  
-  overlay: 'absolute inset-0 bg-black/50 z-10',
-  
-  contentWrapper: `relative z-20 container mx-auto px-4 
-                   flex flex-col items-center`,
-  
-  title: `font-serif text-4xl sm:text-5xl md:text-6xl font-bold 
-          leading-tight mb-4 drop-shadow-md text-primary`,
-  
-  subtitle: `font-sans text-lg md:text-xl mb-8 max-w-2xl 
-             text-primary-foreground`,
-  
-  ctaButton: `bg-gradient-to-r from-primary to-primary/80 
-              hover:from-primary/80 hover:to-primary 
-              text-primary-foreground shadow-lg
-              focus-visible:outline-none focus-visible:ring-2 
-              focus-visible:ring-offset-2 focus-visible:ring-primary`
-} as const;
-
-type MainHeaderProps = {
-  id?: string;
-  className?: string;
-}
+import { BookingButton } from '@/components/BookingButton';
 
 /**
- * MainHeader - Hero section component for the homepage
- * 
- * Displays a full-width hero section with background image, 
- * headline, subtitle, and call-to-action button.
- * 
- * Features:
- * - Responsive design with mobile-first approach
- * - Optimized image loading with fallback
- * - Accessible markup with proper semantic structure
- * - Customizable through HERO_CONFIG constant
+ * MainHeader — Sanctuary-themed hero section (Issue #129)
+ *
+ * Two-column layout on tablet/desktop (content left, arched image right).
+ * Stacks to single column on mobile with image on top.
  */
-const MainHeader: React.FC<MainHeaderProps> = ({ id, className }) => {
-    const reactId = useId();
-    const sectionId = id ?? `main-hero-${reactId}`;
-    const headingId = `${sectionId}-heading`;
-    
-    return (
-        <section 
-          id={sectionId}
-          className={cn(styles.hero, className)}
-          aria-labelledby={headingId}
-        >
-            {/* Background image with overlay */}
-            <div className={styles.imageContainer}>
-                <div className="relative w-full h-full">
-                    <OptimizedImage
-                        src={HERO_CONFIG.image.src}
-                        alt={HERO_CONFIG.image.decorative ? "" : HERO_CONFIG.image.alt}
-                        fill
-                        skipAutoAspectRatio
-                        sizes="100vw"
-                        style={{ objectFit: 'cover' }}
-                        priority
-                        fallback={HERO_CONFIG.image.fallback}
-                    />
-                </div>
-                <div className={styles.overlay} aria-hidden="true" />
+const MainHeader: React.FC = () => {
+  return (
+    <section
+      aria-labelledby="hero-heading"
+      className="py-16 md:py-24 bg-cream"
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col-reverse md:flex-row items-center gap-12">
+
+          {/* ── Left column: content ─────────────────────────────────── */}
+          <div className="flex-1 flex flex-col justify-center gap-6 text-center md:text-left">
+
+            {/* Eyebrow */}
+            <div className="flex items-center gap-3 justify-center md:justify-start" aria-hidden="true">
+              <div className="w-10 h-px bg-clay" />
+              <span className="w-1.5 h-1.5 rounded-full bg-clay block" />
+              <span className="font-sans text-[11px] uppercase tracking-[0.24em] text-taupe">
+                Kelso · Scottish Borders
+              </span>
             </div>
 
-            {/* Main content */}
-            <div className={styles.contentWrapper}>
-                <h1 id={headingId} className={styles.title}>
-                    {HERO_CONFIG.content.title}
-                </h1>
-                
-                <p className={styles.subtitle}>
-                    {HERO_CONFIG.content.subtitle}
-                </p>
-                
-                <Button 
-                  size="lg" 
-                  asChild 
-                  className={styles.ctaButton}
-                >
-                    <Link href={HERO_CONFIG.content.ctaLink}>
-                        {HERO_CONFIG.content.ctaText}
-                    </Link>
-                </Button>
+            {/* H1 */}
+            <h1
+              id="hero-heading"
+              className="font-serif text-4xl md:text-[40px] lg:text-[56px] font-medium leading-tight text-espresso mb-0"
+            >
+              Your sanctuary for{' '}
+              <em className="italic text-sage">heavenly</em>
+              {' '}treatments
+            </h1>
+
+            {/* Lead paragraph */}
+            <p className="font-sans text-[17px] text-taupe max-w-[400px] mx-auto md:mx-0 leading-relaxed mb-0">
+              Bespoke spa therapies in the heart of Kelso, Scottish Borders.
+              Organic, vegan-friendly and deeply relaxing.
+            </p>
+
+            {/* CTA row */}
+            <div className="flex flex-wrap items-center gap-4 justify-center md:justify-start">
+              <BookingButton
+                context="hero"
+                className="rounded-full px-8 py-3 h-auto font-sans font-semibold text-sm hover:bg-sage-hover transition-colors"
+              >
+                Book a treatment
+              </BookingButton>
+              <Link
+                href="/treatments"
+                className="font-sans text-sm text-cocoa hover:underline"
+              >
+                Explore the menu →
+              </Link>
             </div>
-        </section>
-    )
-}
+
+            {/* Trust row */}
+            <div className="flex items-center gap-3 justify-center md:justify-start mt-2">
+              <span className="text-sm text-clay" aria-label="Five star rating">★★★★★</span>
+              <span className="w-px h-4 bg-clay" aria-hidden="true" />
+              <span className="font-sans text-xs text-taupe">
+                Organic &amp; vegan friendly
+              </span>
+            </div>
+          </div>
+
+          {/* ── Right column: arched image ───────────────────────────── */}
+          <div className="flex-1 flex justify-center w-full">
+            <div className="relative w-full max-w-[420px] mx-auto">
+              {/* Clay accent ring — desktop/tablet only */}
+              <div
+                className="absolute inset-0 rounded-t-[260px] border-2 border-clay translate-x-3 translate-y-3 hidden md:block"
+                aria-hidden="true"
+              />
+              {/* Arched image */}
+              <div className="relative z-10 w-full aspect-[3/4] rounded-t-[260px] overflow-hidden max-h-[360px] md:max-h-none">
+                <Image
+                  src="/images/mainPage/young-woman-having-face-massage-relaxing-spa-salon.jpg"
+                  alt="Young woman receiving a relaxing face massage at Heavenly Treatments spa"
+                  fill
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  priority
+                  style={{ objectFit: 'cover' }}
+                />
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+  );
+};
 
 export default MainHeader;

--- a/components/Sections/MarqueeStrip.tsx
+++ b/components/Sections/MarqueeStrip.tsx
@@ -1,49 +1,22 @@
-/**
- * MarqueeStrip — scrolling service category names on a Stone background.
- *
- * Uses a CSS animation (marquee-scroll defined in globals.css) with two
- * identical copies of the item list for a seamless infinite loop.
- * Marked aria-hidden so screen readers skip purely decorative text.
- */
-
-const MARQUEE_ITEMS = [
-  'Seasonal Treatments',
-  'Massages',
+const STRIP_ITEMS = [
+  'Massage',
   'Facials',
-  'Body Treatments',
   'Reflexology',
+  'Body Treatments',
+  'Seasonal Rituals',
 ] as const;
-
-const MarqueeDot = () => (
-  <span className="mx-4 text-clay" aria-hidden="true">·</span>
-);
-
-function MarqueeItemList() {
-  return (
-    <>
-      {MARQUEE_ITEMS.map((item, index) => (
-        <span key={index} className="font-serif italic text-xl text-cocoa">
-          {item}
-          <MarqueeDot />
-        </span>
-      ))}
-    </>
-  );
-}
 
 export default function MarqueeStrip() {
   return (
-    <div className="bg-stone py-4 overflow-hidden" aria-hidden="true">
-      <div className="animate-marquee">
-        {/* First copy */}
-        <span className="flex items-center">
-          <MarqueeItemList />
+    <div className="hidden md:flex bg-stone py-4 items-center justify-center gap-0 overflow-hidden" aria-hidden="true">
+      {STRIP_ITEMS.map((item, index) => (
+        <span key={index} className="flex items-center">
+          <span className="font-serif italic text-xl text-cocoa px-4">{item}</span>
+          {index < STRIP_ITEMS.length - 1 && (
+            <span className="text-clay">·</span>
+          )}
         </span>
-        {/* Duplicate for seamless loop */}
-        <span className="flex items-center">
-          <MarqueeItemList />
-        </span>
-      </div>
+      ))}
     </div>
   );
 }

--- a/components/Sections/MarqueeStrip.tsx
+++ b/components/Sections/MarqueeStrip.tsx
@@ -8,15 +8,17 @@ const STRIP_ITEMS = [
 
 export default function MarqueeStrip() {
   return (
-    <div className="hidden md:flex bg-stone py-4 items-center justify-center gap-0 overflow-hidden" aria-hidden="true">
-      {STRIP_ITEMS.map((item, index) => (
-        <span key={index} className="flex items-center">
-          <span className="font-serif italic text-xl text-cocoa px-4">{item}</span>
-          {index < STRIP_ITEMS.length - 1 && (
-            <span className="text-clay">·</span>
-          )}
-        </span>
-      ))}
+    <div className="hidden md:block bg-stone py-4 overflow-hidden" aria-hidden="true">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between">
+        {STRIP_ITEMS.map((item, index) => (
+          <span key={index} className="flex items-center">
+            <span className="font-serif italic text-xl text-cocoa px-4">{item}</span>
+            {index < STRIP_ITEMS.length - 1 && (
+              <span className="text-clay">·</span>
+            )}
+          </span>
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/Sections/MarqueeStrip.tsx
+++ b/components/Sections/MarqueeStrip.tsx
@@ -1,0 +1,49 @@
+/**
+ * MarqueeStrip — scrolling service category names on a Stone background.
+ *
+ * Uses a CSS animation (marquee-scroll defined in globals.css) with two
+ * identical copies of the item list for a seamless infinite loop.
+ * Marked aria-hidden so screen readers skip purely decorative text.
+ */
+
+const MARQUEE_ITEMS = [
+  'Seasonal Treatments',
+  'Massages',
+  'Facials',
+  'Body Treatments',
+  'Reflexology',
+] as const;
+
+const MarqueeDot = () => (
+  <span className="mx-4 text-clay" aria-hidden="true">·</span>
+);
+
+function MarqueeItemList() {
+  return (
+    <>
+      {MARQUEE_ITEMS.map((item, index) => (
+        <span key={index} className="font-serif italic text-xl text-cocoa">
+          {item}
+          <MarqueeDot />
+        </span>
+      ))}
+    </>
+  );
+}
+
+export default function MarqueeStrip() {
+  return (
+    <div className="bg-stone py-4 overflow-hidden" aria-hidden="true">
+      <div className="animate-marquee">
+        {/* First copy */}
+        <span className="flex items-center">
+          <MarqueeItemList />
+        </span>
+        {/* Duplicate for seamless loop */}
+        <span className="flex items-center">
+          <MarqueeItemList />
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/Sections/Services.tsx
+++ b/components/Sections/Services.tsx
@@ -1,86 +1,155 @@
-import React from 'react';
 import Link from 'next/link';
-import { TreatmentCategory } from '@/lib/data/treatments';
 
-interface ServicesSectionProps {
-  categories: TreatmentCategory[];
-}
+const SERVICES = [
+  {
+    num: '01',
+    name: 'Seasonal Treatments',
+    slug: 'seasonal-treatments',
+    descDesktop: 'Relax and rejuvenate with a rotating range of seasonal rituals.',
+    descTablet: 'Relax with a rotating range of seasonal rituals.',
+  },
+  {
+    num: '02',
+    name: 'Massages',
+    slug: 'massages',
+    descDesktop: 'Melt away tension with a range of therapeutic and relaxing massages.',
+    descTablet: 'Therapeutic and relaxing massages.',
+  },
+  {
+    num: '03',
+    name: 'Facials',
+    slug: 'facials',
+    descDesktop: 'Achieve glowing, healthy skin with results-driven facial treatments.',
+    descTablet: 'Glowing, healthy skin with results-driven facials.',
+  },
+  {
+    num: '04',
+    name: 'Body Treatments',
+    slug: 'body-treatments',
+    descDesktop: 'Nourish and pamper your body from head to toe.',
+    descTablet: 'Nourish and pamper your body from head to toe.',
+  },
+  {
+    num: '05',
+    name: 'Reflexology',
+    slug: 'reflexology',
+    descDesktop: 'Heal from within with restorative reflexology treatments.',
+    descTablet: 'Restore balance and calm through the feet.',
+  },
+] as const;
 
-/**
- * ServicesSection — numbered treatment category cards grid (Issue #129)
- *
- * Renders 5 numbered cards (01–05) for each treatment category plus
- * a Sage-green CTA tile. Hover lift/shadow on desktop; subtle clay
- * border on mobile. Server component — no client state required.
- */
-const ServicesSection: React.FC<ServicesSectionProps> = ({ categories }) => {
+const MOBILE_SERVICES = [
+  { num: '01', name: 'Massages', subtitle: 'Therapeutic & relaxing', slug: 'massages' },
+  { num: '02', name: 'Facials', subtitle: 'Glowing, healthy skin', slug: 'facials' },
+  { num: '03', name: 'Reflexology', subtitle: 'Restore your balance', slug: 'reflexology' },
+] as const;
+
+// Tablet shows 4 items (no Body Treatments), renumbered 01–04
+const TABLET_SERVICES = SERVICES.filter(
+  (s) => s.slug !== 'body-treatments',
+).map((s, i) => ({ ...s, tabletNum: String(i + 1).padStart(2, '0') }));
+
+const CTA_CONTENT = {
+  heading: 'Not sure where to start?',
+  body: "Tell me what you need and I’ll guide you to the perfect treatment.",
+  link: 'Get in touch →',
+  href: '/contact',
+} as const;
+
+export default function ServicesSection() {
   return (
-    <section
-      aria-labelledby="services-heading"
-      className="py-16 md:py-24 bg-cream"
-    >
+    <section aria-labelledby="services-heading" className="py-16 md:py-24 bg-stone">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
 
-        {/* Section heading */}
-        <div className="mb-12 text-center md:text-left">
+        {/* Section header */}
+        <div className="mb-10 md:mb-14 text-center">
+          <p className="font-sans text-[11px] uppercase tracking-[0.24em] text-sage mb-4">
+            <span className="sm:hidden">My Services</span>
+            <span className="hidden sm:inline">Explore My Services</span>
+          </p>
           <h2
             id="services-heading"
-            className="font-serif text-espresso mb-2"
+            className="font-serif text-espresso mb-0 text-4xl md:text-5xl lg:text-[56px] leading-[1.1]"
           >
-            Our treatments
+            <span className="lg:hidden">Treatments to soothe &amp; restore</span>
+            <span className="hidden lg:inline">
+              Treatments designed to soothe,<br />rejuvenate &amp; restore balance
+            </span>
           </h2>
-          <p className="font-sans text-base text-taupe mb-0">
-            Expertly curated for your well-being
-          </p>
         </div>
 
-        {/* Cards grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-
-          {/* Category cards */}
-          {categories.map((category, index) => (
+        {/* ─── MOBILE: list rows ─────────────────────────── */}
+        <div className="sm:hidden flex flex-col gap-3">
+          {MOBILE_SERVICES.map((s) => (
             <Link
-              key={category.id}
-              href={`/treatments/${category.slug}`}
-              className="group"
+              key={s.slug}
+              href={`/treatments/${s.slug}`}
+              className="group bg-warm-white rounded-2xl px-5 py-5 flex items-center gap-4"
             >
-              <article className="bg-warm-white rounded-2xl p-6 flex flex-col gap-3 h-full border border-clay/30 md:border-transparent transition-all duration-300 ease-out md:hover:-translate-y-[6px] md:hover:shadow-xl">
-                <span className="font-sans text-xs text-clay font-semibold tracking-widest">
-                  {String(index + 1).padStart(2, '0')}
-                </span>
-                <h3 className="font-serif text-xl text-espresso mb-0 leading-snug">
-                  {category.name}
-                </h3>
+              <span className="font-sans text-sm text-clay w-6 shrink-0">{s.num}</span>
+              <div className="flex-1">
+                <p className="font-serif text-xl text-espresso mb-0 leading-snug">{s.name}</p>
+                <p className="font-sans text-sm text-taupe mb-0">{s.subtitle}</p>
+              </div>
+              <span className="text-sage text-base">&#8594;</span>
+            </Link>
+          ))}
+          <Link
+            href="/treatments"
+            className="font-sans text-sm font-bold text-espresso text-center mt-4 block"
+          >
+            View all treatments &#8594;
+          </Link>
+        </div>
+
+        {/* ─── TABLET: 2×2 grid + full-width CTA banner ─── */}
+        <div className="hidden sm:flex lg:hidden flex-col gap-4">
+          <div className="grid grid-cols-2 gap-4">
+            {TABLET_SERVICES.map((s) => (
+              <Link key={s.slug} href={`/treatments/${s.slug}`} className="group">
+                <article className="bg-warm-white rounded-2xl p-6 h-full flex flex-col gap-3">
+                  <span className="font-sans text-xs text-clay">{s.tabletNum}</span>
+                  <h3 className="font-serif text-2xl text-espresso mb-0 leading-snug">{s.name}</h3>
+                  <p className="font-sans text-sm text-taupe leading-relaxed flex-1 mb-0">
+                    {s.descTablet}
+                  </p>
+                </article>
+              </Link>
+            ))}
+          </div>
+          <Link href={CTA_CONTENT.href} className="group">
+            <article className="bg-sage rounded-2xl p-8 flex flex-col gap-3">
+              <h3 className="font-serif text-2xl text-warm-white mb-0">{CTA_CONTENT.heading}</h3>
+              <p className="font-sans text-sm text-warm-white/80 mb-0">{CTA_CONTENT.body}</p>
+              <span className="font-sans text-sm font-bold text-warm-white">{CTA_CONTENT.link}</span>
+            </article>
+          </Link>
+        </div>
+
+        {/* ─── DESKTOP: 3-col grid with CTA tile ─────────── */}
+        <div className="hidden lg:grid grid-cols-3 gap-6">
+          {SERVICES.map((s) => (
+            <Link key={s.slug} href={`/treatments/${s.slug}`} className="group">
+              <article className="bg-warm-white rounded-2xl p-6 xl:p-8 h-full flex flex-col gap-3">
+                <span className="font-sans text-xs text-clay">{s.num}</span>
+                <h3 className="font-serif text-2xl text-espresso mb-0 leading-snug">{s.name}</h3>
                 <p className="font-sans text-sm text-taupe leading-relaxed flex-1 mb-0">
-                  {category.shortDescription}
+                  {s.descDesktop}
                 </p>
-                <span className="font-sans text-sm text-sage font-semibold group-hover:underline">
-                  Explore →
-                </span>
+                <span className="font-sans text-sm text-clay group-hover:underline">Discover &#8594;</span>
               </article>
             </Link>
           ))}
-
-          {/* CTA tile */}
-          <Link href="/contact" className="group">
-            <article className="bg-sage rounded-2xl p-6 flex flex-col gap-3 h-full justify-center items-center text-center transition-all duration-300 ease-out md:hover:-translate-y-[6px] md:hover:bg-sage-hover">
-              <span className="text-2xl text-warm-white" aria-hidden="true">✦</span>
-              <h3 className="font-serif text-xl text-warm-white mb-0 leading-snug">
-                Not sure where to start?
-              </h3>
-              <p className="font-sans text-sm text-warm-white/80 mb-0">
-                Get in touch and I&apos;ll help you choose the perfect treatment.
-              </p>
-              <span className="font-sans text-sm text-warm-white font-semibold">
-                Get in touch →
-              </span>
+          <Link href={CTA_CONTENT.href} className="group">
+            <article className="bg-sage rounded-2xl p-6 xl:p-8 h-full flex flex-col gap-4">
+              <h3 className="font-serif text-2xl text-warm-white mb-0">{CTA_CONTENT.heading}</h3>
+              <p className="font-sans text-sm text-warm-white/80 flex-1 mb-0">{CTA_CONTENT.body}</p>
+              <span className="font-sans text-sm font-bold text-warm-white">{CTA_CONTENT.link}</span>
             </article>
           </Link>
-
         </div>
+
       </div>
     </section>
   );
-};
-
-export default ServicesSection;
+}

--- a/components/Sections/Services.tsx
+++ b/components/Sections/Services.tsx
@@ -69,7 +69,7 @@ export default function ServicesSection() {
           </p>
           <h2
             id="services-heading"
-            className="font-serif text-espresso mb-0 text-4xl md:text-5xl lg:text-[56px] leading-[1.1]"
+            className="font-serif text-espresso mb-0 text-4xl md:text-[44px] lg:text-[52px] leading-[1.1]"
           >
             <span className="lg:hidden">Treatments to soothe &amp; restore</span>
             <span className="hidden lg:inline">
@@ -84,11 +84,11 @@ export default function ServicesSection() {
             <Link
               key={s.slug}
               href={`/treatments/${s.slug}`}
-              className="group bg-warm-white rounded-2xl px-5 py-5 flex items-center gap-4"
+              className="group bg-warm-white rounded-2xl px-5 py-5 flex items-center gap-4 transition-all duration-300 ease-out active:scale-[0.98]"
             >
               <span className="font-sans text-sm text-clay w-6 shrink-0">{s.num}</span>
               <div className="flex-1">
-                <p className="font-serif text-xl text-espresso mb-0 leading-snug">{s.name}</p>
+                <p className="font-serif text-2xl text-espresso mb-0 leading-snug">{s.name}</p>
                 <p className="font-sans text-sm text-taupe mb-0">{s.subtitle}</p>
               </div>
               <span className="text-sage text-base">&#8594;</span>
@@ -107,8 +107,8 @@ export default function ServicesSection() {
           <div className="grid grid-cols-2 gap-4">
             {TABLET_SERVICES.map((s) => (
               <Link key={s.slug} href={`/treatments/${s.slug}`} className="group">
-                <article className="bg-warm-white rounded-2xl p-6 h-full flex flex-col gap-3">
-                  <span className="font-sans text-xs text-clay">{s.tabletNum}</span>
+                <article className="bg-warm-white rounded-2xl p-6 h-full flex flex-col gap-3 transition-all duration-300 ease-out hover:-translate-y-[6px] hover:shadow-xl">
+                  <span className="font-sans text-sm text-clay">{s.tabletNum}</span>
                   <h3 className="font-serif text-2xl text-espresso mb-0 leading-snug">{s.name}</h3>
                   <p className="font-sans text-sm text-taupe leading-relaxed flex-1 mb-0">
                     {s.descTablet}
@@ -118,8 +118,8 @@ export default function ServicesSection() {
             ))}
           </div>
           <Link href={CTA_CONTENT.href} className="group">
-            <article className="bg-sage rounded-2xl p-8 flex flex-col gap-3">
-              <h3 className="font-serif text-2xl text-warm-white mb-0">{CTA_CONTENT.heading}</h3>
+            <article className="bg-sage rounded-2xl p-8 flex flex-col gap-3 transition-all duration-300 ease-out hover:-translate-y-[6px] hover:shadow-xl">
+              <h3 className="font-serif italic text-2xl text-warm-white mb-0">{CTA_CONTENT.heading}</h3>
               <p className="font-sans text-sm text-warm-white/80 mb-0">{CTA_CONTENT.body}</p>
               <span className="font-sans text-sm font-bold text-warm-white">{CTA_CONTENT.link}</span>
             </article>
@@ -130,19 +130,19 @@ export default function ServicesSection() {
         <div className="hidden lg:grid grid-cols-3 gap-6">
           {SERVICES.map((s) => (
             <Link key={s.slug} href={`/treatments/${s.slug}`} className="group">
-              <article className="bg-warm-white rounded-2xl p-6 xl:p-8 h-full flex flex-col gap-3">
-                <span className="font-sans text-xs text-clay">{s.num}</span>
+              <article className="bg-warm-white rounded-2xl p-6 xl:p-8 h-full flex flex-col gap-3 transition-all duration-300 ease-out hover:-translate-y-[6px] hover:shadow-xl">
+                <span className="font-sans text-sm text-clay">{s.num}</span>
                 <h3 className="font-serif text-2xl text-espresso mb-0 leading-snug">{s.name}</h3>
                 <p className="font-sans text-sm text-taupe leading-relaxed flex-1 mb-0">
                   {s.descDesktop}
                 </p>
-                <span className="font-sans text-sm text-clay group-hover:underline">Discover &#8594;</span>
+                <span className="font-sans text-sm font-semibold text-sage group-hover:underline">Discover &#8594;</span>
               </article>
             </Link>
           ))}
           <Link href={CTA_CONTENT.href} className="group">
-            <article className="bg-sage rounded-2xl p-6 xl:p-8 h-full flex flex-col gap-4">
-              <h3 className="font-serif text-2xl text-warm-white mb-0">{CTA_CONTENT.heading}</h3>
+            <article className="bg-sage rounded-2xl p-6 xl:p-8 h-full flex flex-col gap-4 transition-all duration-300 ease-out hover:-translate-y-[6px] hover:shadow-xl">
+              <h3 className="font-serif italic text-2xl text-warm-white mb-0">{CTA_CONTENT.heading}</h3>
               <p className="font-sans text-sm text-warm-white/80 flex-1 mb-0">{CTA_CONTENT.body}</p>
               <span className="font-sans text-sm font-bold text-warm-white">{CTA_CONTENT.link}</span>
             </article>

--- a/components/Sections/Services.tsx
+++ b/components/Sections/Services.tsx
@@ -1,92 +1,86 @@
-'use client';
-
-import React, { useState } from 'react';
-import Image from 'next/image';
+import React from 'react';
 import Link from 'next/link';
 import { TreatmentCategory } from '@/lib/data/treatments';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { cn } from '@/lib/utils';
-import { config } from '@/lib/config';
 
 interface ServicesSectionProps {
   categories: TreatmentCategory[];
-  showAllButton?: boolean;
 }
 
-const ServicesSection: React.FC<ServicesSectionProps> = ({ categories, showAllButton = true }) => {
-    const [showAll, setShowAll] = useState(!showAllButton);
-    const totalCategories = categories.length;
-    const initialVisibleCount = config.ui.INITIAL_VISIBLE_TREATMENTS;
+/**
+ * ServicesSection — numbered treatment category cards grid (Issue #129)
+ *
+ * Renders 5 numbered cards (01–05) for each treatment category plus
+ * a Sage-green CTA tile. Hover lift/shadow on desktop; subtle clay
+ * border on mobile. Server component — no client state required.
+ */
+const ServicesSection: React.FC<ServicesSectionProps> = ({ categories }) => {
+  return (
+    <section
+      aria-labelledby="services-heading"
+      className="py-16 md:py-24 bg-cream"
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
 
-    return (
-        <section className="py-16 md:py-24 bg-primary/10">
-            <div className="container mx-auto px-4">
-                <h2 className="font-serif text-3xl md:text-4xl font-semibold text-primary text-center mb-6">
-                    Explore My Services
-                </h2>
-                <p className="font-sans text-lg text-foreground/80 text-center mb-12 max-w-xl mx-auto">
-                    Indulge in treatments designed to soothe your body, rejuvenate your skin, and restore balance.
+        {/* Section heading */}
+        <div className="mb-12 text-center md:text-left">
+          <h2
+            id="services-heading"
+            className="font-serif text-espresso mb-2"
+          >
+            Our treatments
+          </h2>
+          <p className="font-sans text-base text-taupe mb-0">
+            Expertly curated for your well-being
+          </p>
+        </div>
+
+        {/* Cards grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+
+          {/* Category cards */}
+          {categories.map((category, index) => (
+            <Link
+              key={category.id}
+              href={`/treatments/${category.slug}`}
+              className="group"
+            >
+              <article className="bg-warm-white rounded-2xl p-6 flex flex-col gap-3 h-full border border-clay/30 md:border-transparent transition-all duration-300 ease-out md:hover:-translate-y-[6px] md:hover:shadow-xl">
+                <span className="font-sans text-xs text-clay font-semibold tracking-widest">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <h3 className="font-serif text-xl text-espresso mb-0 leading-snug">
+                  {category.name}
+                </h3>
+                <p className="font-sans text-sm text-taupe leading-relaxed flex-1 mb-0">
+                  {category.shortDescription}
                 </p>
+                <span className="font-sans text-sm text-sage font-semibold group-hover:underline">
+                  Explore →
+                </span>
+              </article>
+            </Link>
+          ))}
 
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-                    {categories.map((category, index) => (
-                        <Link
-                            key={category.id}
-                            href={`/treatments?category=${category.slug}`}
-                            className={cn(
-                                'group block transition-all duration-300 ease-in-out hover:-translate-y-1',
-                                showAllButton && index >= initialVisibleCount && !showAll ? 'hidden' : 'block',
-                                'md:block'
-                             )}
-                        >
-                             <Card className="flex flex-col h-full overflow-hidden shadow-md hover:shadow-xl hover:-translate-y-1 group p-0 transition-all duration-300">
-                                 <div className="relative w-full h-52 overflow-hidden">
-                                    {category.image ? (
-                                        <Image
-                                            src={category.image}
-                                            alt={category.name}
-                                            fill
-                                            style={{ objectFit: 'cover' }}
-                                            className="transition-transform duration-300 group-hover:scale-105"
-                                            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                                        />
-                                    ) : (
-                                        <div className="w-full h-full bg-secondary/20 flex items-center justify-center">
-                                            <span className="text-muted-foreground text-sm">Image coming soon</span>
-                                        </div>
-                                    )}
-                                 </div>
-                                 <CardHeader>
-                                     <h3 className="font-serif text-xl font-medium text-primary group-hover:text-primary/80">
-                                         {category.name}
-                                     </h3>
-                                 </CardHeader>
-                                 <CardContent className="flex-grow">
-                                     <p className="font-sans text-sm text-foreground/80 line-clamp-3">
-                                         {category.shortDescription || category.description || 'Discover relaxing treatments.'}
-                                     </p>
-                                 </CardContent>
-                             </Card>
-                         </Link>
-                    ))}
-                </div>
+          {/* CTA tile */}
+          <Link href="/contact" className="group">
+            <article className="bg-sage rounded-2xl p-6 flex flex-col gap-3 h-full justify-center items-center text-center transition-all duration-300 ease-out md:hover:-translate-y-[6px] md:hover:bg-sage-hover">
+              <span className="text-2xl text-warm-white" aria-hidden="true">✦</span>
+              <h3 className="font-serif text-xl text-warm-white mb-0 leading-snug">
+                Not sure where to start?
+              </h3>
+              <p className="font-sans text-sm text-warm-white/80 mb-0">
+                Get in touch and I&apos;ll help you choose the perfect treatment.
+              </p>
+              <span className="font-sans text-sm text-warm-white font-semibold">
+                Get in touch →
+              </span>
+            </article>
+          </Link>
 
-                {showAllButton && !showAll && totalCategories > initialVisibleCount && (
-                    <div className="text-center mt-12 md:hidden">
-                        <Button onClick={(e) => { e.stopPropagation(); setShowAll(true); }} variant="outline" size="lg">
-                            Show All Services ({totalCategories})
-                        </Button>
-                    </div>
-                )}
-                 <div className="text-center mt-12">
-                      <Button variant="default" size="lg" asChild>
-                         <Link href="/treatments">View All Treatments</Link>
-                      </Button>
-                 </div>
-            </div>
-        </section>
-    );
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default ServicesSection;

--- a/lib/abTesting/getBookingUrl.ts
+++ b/lib/abTesting/getBookingUrl.ts
@@ -9,6 +9,7 @@ import {
 
 export type BookingContext =
   | 'navbar'
+  | 'hero'
   | 'treatment-card'
   | 'treatment-detail'
   | 'location-section';


### PR DESCRIPTION
## Summary

Completes the Sanctuary redesign for all four content sections on the homepage, matching the master design spec across all three breakpoints (mobile, tablet, desktop).

- **8 commits** · 7 files changed · +374 / -257 lines
- **Risk level:** Low — static sections with no new data fetching or client state
- **Follows on from:** PR #137 (nav, footer, booking band)

---

## What Changed

### 🦸 `MainHeader.tsx` — Two-column hero layout
- Replaced full-bleed image overlay with cream background + arched portrait image (right column)
- Left column: eyebrow tag, H1 with italic sage `soul.`, lead paragraph, booking CTA, trust row (stars + vegan/cruelty-free)
- Trust row rendered twice (CSS show/hide) so it appears *after* the image on mobile and *beside* the heading on desktop — avoids DOM reordering
- Extracted `TrustRowContent` as a module-level component (`rerender-no-inline-components`)
- Added `'hero'` context to `BookingButton` A/B tracking
- **Fixed:** reduced right-column image `max-w-[560px]` → `max-w-[440px]` to match design spec proportions (section height ~950px → ~740px on xl viewports)

### ⚡ `MarqueeStrip.tsx` — New static service band
- Thin horizontal strip between hero and intro: `Massage · Facials · Reflexology · Body Treatments · Seasonal Rituals`
- Desktop-only (`hidden md:block`), `aria-hidden="true"`, pure server component

### 🌿 `Introduction.tsx` — Two-column about section
- Replaced text-only centered block with image (left) + bio copy (right) desktop layout
- Portrait image with sage badge overlay (`5★ Spa Trained`)
- Removed `'use client'` and `useId` — now a pure server component
- Section is `hidden lg:block` (desktop only per design spec)

### 🃏 `Services.tsx` — Three-breakpoint card layout
- Removed `categories` prop and Sanity data dependency — layout and copy are design-spec'd static
- **Mobile:** 3 list rows (Massages, Facials, Reflexology) + "View all treatments →"
- **Tablet:** 2×2 card grid (4 services, Body Treatments excluded) + full-width sage CTA banner
- **Desktop:** 3-col grid (all 5 services) + CTA tile as 6th card
- Removed `'use client'` — pure server component

### 🗂️ `app/page.tsx`
- Removed `getCategories()` Sanity call (Services no longer needs it)
- Removed `DynamicExperienceSection`, `DynamicServicesSection`, `LocationAndBookingSection` (not in Sanctuary homepage spec)
- Added `MarqueeStrip` static import

---

## Why These Changes

The Sanctuary redesign brief specifies a content-first homepage with warm cream/stone backgrounds, serif headings, and a natural spa aesthetic. The previous sections used generic shadcn card layouts with live CMS images. The new sections use design-spec copy and layout with zero runtime data fetching, which eliminates a Sanity waterfall on every homepage load.

---

## Performance Impact

| Change | Impact |
|--------|--------|
| Removed `getCategories()` Sanity call | -1 network round-trip on homepage load |
| `Services.tsx` → server component | Removes client JS bundle for this section |
| `Introduction.tsx` → server component | Removes client JS bundle + `useId` hydration |
| Hero image uses `priority` | Correct LCP candidate preloaded |
| Introduction portrait: no `priority` | Lazy-loaded (below fold, `hidden lg:block`) |

---

## Checklist

- [x] No new `'use client'` added unnecessarily
- [x] Static data at module level (not recreated per render)
- [x] `Image` components have correct `sizes` props
- [x] `aria-*` attributes on decorative elements
- [x] Three breakpoints tested: mobile list / tablet grid / desktop grid
- [x] No Sanity queries added to homepage
- [x] TypeScript — no type errors
- [x] `npm run lint` passes

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)