### PR TITLE
feat(treatments): responsive accordion page with Sanctuary design spec

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -78,7 +78,7 @@ async function HomePage() {
   const jsonLdContent = JSON.stringify([webSiteJsonLd, businessJsonLd, faqJsonLd]);
 
   return (
-    <MainLayout>
+    <MainLayout showCtaBand>
       <Script
         id="homepage-jsonld"
         type="application/ld+json"

--- a/app/treatments/page.tsx
+++ b/app/treatments/page.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import type { Metadata } from 'next';
-import { getTreatments, getCategories } from '@/lib/cms/treatments';
-import { TreatmentCategory } from '@/lib/data/treatments';
+import Link from 'next/link';
+import { getCategories } from '@/lib/cms/treatments';
+import { allTreatments, type TreatmentCategory } from '@/lib/data/treatments';
 import { MainLayout } from '@/components/Layout/MainLayout';
-import CategoryFilters from '@/components/Treatments/CategoryFilters';
-import FilteredTreatmentsDisplay from '@/components/Treatments/FilteredTreatmentsDisplay';
+import TreatmentsAccordion from '@/components/Sections/TreatmentsAccordion';
 import { contactInfo } from '@/lib/data/contactInfo';
 import Script from 'next/script';
 import {
@@ -16,6 +16,8 @@ import { config } from '@/lib/config';
 
 // Revalidate this page every hour
 export const revalidate = 3600;
+
+const TRUST_CHIPS = ['✦ Organic & natural', '✦ 100% vegan & cruelty-free', '✦ By appointment, Mon–Sun'];
 
 export async function generateMetadata(): Promise<Metadata> {
   const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || '';
@@ -52,15 +54,20 @@ export async function generateMetadata(): Promise<Metadata> {
 /**
  * TreatmentsPage Component
  *
- * Displays the complete treatment menu with all available treatments.
- * Category-specific filtering is now handled by /treatments/[categorySlug]/page.tsx
+ * Renders an intro band, a hybrid accordion (categories server-side,
+ * treatments lazy-loaded per panel via server action), and a closing CTA.
  */
 export default async function TreatmentsPage() {
   const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || '';
 
-  // Fetch all data
+  // Categories are fetched server-side; treatments load lazily per accordion panel
   const categories: TreatmentCategory[] = await getCategories();
-  const allTreatments = await getTreatments();
+
+  // Pre-compute treatment counts in a single pass so accordion headers show counts immediately
+  const initialCounts = allTreatments.reduce<Record<string, number>>((acc, t) => {
+    acc[t.category] = (acc[t.category] ?? 0) + 1;
+    return acc;
+  }, {});
 
   // Generate JSON-LD structured data (server-generated, trusted content)
   const businessJsonLd = generateHealthAndBeautyBusinessJsonLd(contactInfo as ContactInfo);
@@ -70,8 +77,7 @@ export default async function TreatmentsPage() {
   ];
   const breadcrumbJsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
 
-  // JSON-LD injection - standard Next.js pattern for structured data
-  // Content is server-generated from trusted utility functions
+  // JSON-LD injection — standard Next.js pattern for structured data
   const jsonLdScript = (
     <Script
       id="treatments-jsonld"
@@ -83,25 +89,80 @@ export default async function TreatmentsPage() {
   return (
     <MainLayout>
       {jsonLdScript}
-      <section className="py-16 md:py-24 bg-primary/10">
-        <div className="container mx-auto px-4">
-          <h1 className="font-serif text-3xl md:text-4xl font-semibold text-primary text-center mb-8">
-            Complete Treatment Spa Menu in Kelso
-          </h1>
 
-          <div className="flex justify-center mb-2 lg:mb-12">
-            <CategoryFilters
-              selectedCategory="all"
-              categories={categories}
-            />
+      {/* ── Intro band ────────────────────────────────────────────────── */}
+      <div className="bg-stone border-b border-cocoa/10">
+        <div className="max-w-[1180px] mx-auto pt-[30px] pb-7 px-[22px] md:pt-[62px] md:pb-[56px] md:px-8">
+
+          {/* Breadcrumb */}
+          <nav aria-label="Breadcrumb" className="hidden sm:flex items-center mb-[22px] font-sans text-[12.5px]">
+            <Link href="/" className="text-sage font-semibold hover:opacity-80 transition-opacity">
+              Home
+            </Link>
+            <span className="text-clay mx-2" aria-hidden="true">/</span>
+            <span className="text-[#8C8276]">Treatments</span>
+          </nav>
+
+          {/* Eyebrow */}
+          <div className="flex items-center gap-[10px] sm:gap-3 mb-[14px] sm:mb-[18px]" aria-hidden="true">
+            <span className="w-[22px] sm:w-7 h-px bg-clay flex-shrink-0" />
+            <span className="font-sans text-[10.5px] sm:text-[12px] tracking-[0.2em] sm:tracking-[0.22em] uppercase text-sage font-semibold">
+              The Treatment Menu
+            </span>
           </div>
 
-          <FilteredTreatmentsDisplay
-            filteredTreatments={allTreatments}
-            currentSelection="all"
-          />
+          {/* H1 */}
+          <h1 className="font-serif text-[36px] sm:text-[46px] lg:text-[60px] font-medium text-[#3A332C] tracking-[-0.01em] max-w-[720px] mb-3 sm:mb-5 leading-[1.04]">
+            Every treatment, gathered in one calm place
+          </h1>
+
+          {/* Lead copy — shorter on mobile, longer on tablet+ */}
+          <p className="sm:hidden font-sans text-[14.5px] leading-[1.65] text-taupe max-w-[560px]">
+            Tap a category to explore, then tap any treatment for the full details.
+          </p>
+          <p className="hidden sm:block font-sans text-[16.5px] leading-[1.7] text-taupe max-w-[560px] mb-6">
+            Each treatment uses high-quality, primarily organic and natural products — and everything
+            I use is vegan and cruelty-free. Browse by category, then tap any treatment for the full
+            details.
+          </p>
+
+          {/* Trust chips */}
+          <div className="hidden sm:flex flex-wrap gap-[14px]">
+            {TRUST_CHIPS.map((chip) => (
+              <span
+                key={chip}
+                className="font-sans text-[12px] tracking-[0.06em] text-cocoa bg-warm-white border border-cocoa/10 py-2 px-4 rounded-full"
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
         </div>
-      </section>
+      </div>
+
+      {/* ── Accordion + CTA card on cream background ─────────────────── */}
+      <div className="bg-cream">
+        <TreatmentsAccordion categories={categories} initialCounts={initialCounts} />
+
+        {/* "Not sure which to choose?" card — inline, per design */}
+        <div className="max-w-[1180px] mx-auto px-[18px] sm:px-8 pt-4 pb-8 sm:pt-0 sm:pb-[90px]">
+          <div className="bg-sage rounded-2xl sm:rounded-[20px] py-[30px] px-6 sm:p-[54px] text-center">
+            <h2 className="font-serif text-[26px] sm:text-[40px] font-medium text-warm-white mb-[10px] sm:mb-[14px] leading-tight">
+              Not sure which to choose?
+            </h2>
+            <p className="font-sans text-[13.5px] sm:text-[16px] leading-[1.6] sm:leading-[1.7] text-warm-white/88 max-w-[460px] mx-auto mb-5 sm:mb-7">
+              Tell me how you&apos;d like to feel and I&apos;ll help you find the perfect treatment.
+              Appointments Mon–Sun, 10am–5pm.
+            </p>
+            <Link
+              href="/contact"
+              className="inline-block font-sans font-bold text-[13.5px] sm:text-[14.5px] bg-warm-white text-[#3A332C] px-[30px] sm:px-9 py-[14px] sm:py-4 rounded-full hover:opacity-90 transition-opacity"
+            >
+              Contact me &amp; book
+            </Link>
+          </div>
+        </div>
+      </div>
     </MainLayout>
   );
 }

--- a/components/Layout/MainLayout.tsx
+++ b/components/Layout/MainLayout.tsx
@@ -10,16 +10,17 @@ import { PromotionalDialog } from '@/components/Layout/PromotionalDialog';
 
 interface MainLayoutProps {
   children: ReactNode;
+  showCtaBand?: boolean;
 }
 
-export const MainLayout: React.FC<MainLayoutProps> = async ({ children }) => {
+export const MainLayout: React.FC<MainLayoutProps> = async ({ children, showCtaBand = false }) => {
   const promotionalOffer = await getActivePromotionalOffer();
 
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="grow">{children}</main>
-      <BookingCtaBand />
+      {showCtaBand && <BookingCtaBand />}
       <Footer />
       <CookieConsentWrapper />
       {promotionalOffer && (

--- a/components/Sections/TreatmentsAccordion.tsx
+++ b/components/Sections/TreatmentsAccordion.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { fetchCategoryTreatmentMenu } from '@/app/treatments/actions';
+import type { TreatmentCategory, TreatmentMenuItem } from '@/lib/data/treatments';
+
+interface TreatmentsAccordionProps {
+  categories: TreatmentCategory[];
+  initialCounts: Record<string, number>;
+}
+
+function SkeletonRows() {
+  return (
+    <div className="px-5 sm:px-7 pb-2 sm:pb-3">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="py-4 sm:py-5 border-t border-[rgba(74,64,56,0.1)]">
+          <div className="animate-pulse flex justify-between gap-6">
+            <div className="flex-1 space-y-2">
+              <div className="h-6 bg-stone rounded w-44" />
+              <div className="h-3 bg-stone rounded w-20" />
+              <div className="h-4 bg-stone rounded w-64 mt-1" />
+            </div>
+            <div className="flex flex-col items-end gap-2 shrink-0">
+              <div className="h-6 bg-stone rounded w-12" />
+              <div className="h-3 bg-stone rounded w-20" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function TreatmentsAccordion({ categories, initialCounts }: TreatmentsAccordionProps) {
+  const [openSlug, setOpenSlug] = useState<string | null>(null);
+  const [cache, setCache] = useState<Record<string, TreatmentMenuItem[]>>({});
+  const [loading, setLoading] = useState<Record<string, boolean>>({});
+
+  async function handleToggle(slug: string) {
+    // Close if same panel is open
+    if (openSlug === slug) {
+      setOpenSlug(null);
+      return;
+    }
+
+    // Open panel immediately — also start loading if not cached/in-flight
+    setOpenSlug(slug);
+
+    if (cache[slug] !== undefined || loading[slug]) return;
+
+    setLoading((prev) => ({ ...prev, [slug]: true }));
+    try {
+      const treatments = await fetchCategoryTreatmentMenu(slug);
+      setCache((prev) => ({ ...prev, [slug]: treatments }));
+    } finally {
+      setLoading((prev) => ({ ...prev, [slug]: false }));
+    }
+  }
+
+  return (
+    <section
+      aria-label="Treatment categories"
+      className="max-w-[1180px] mx-auto px-[18px] sm:px-8 pt-[22px] sm:pt-[70px] pb-2 sm:pb-[30px]"
+    >
+      {categories.map((category) => {
+        const isOpen = openSlug === category.slug;
+        const panelId = `accordion-panel-${category.slug}`;
+        const headerId = `accordion-header-${category.slug}`;
+        const treatments = cache[category.slug];
+        const isLoading = loading[category.slug] ?? false;
+        const count = treatments !== undefined
+          ? treatments.length
+          : (initialCounts[category.slug] ?? null);
+
+        return (
+          <div
+            key={category.id}
+            className="mb-3 sm:mb-4 bg-warm-white border border-[rgba(74,64,56,0.08)] rounded-2xl overflow-hidden"
+          >
+            {/* Accordion trigger — entire header row is the interactive button */}
+            <button
+              id={headerId}
+              type="button"
+              aria-expanded={isOpen}
+              aria-controls={panelId}
+              onClick={() => { void handleToggle(category.slug); }}
+              className="w-full flex items-center gap-3 sm:gap-[18px] px-5 py-[18px] sm:px-7 sm:py-6 cursor-pointer text-left"
+            >
+              {/* Mobile: name + count stacked, fills remaining space */}
+              <div className="flex-1 min-w-0 sm:hidden">
+                <span className="font-serif text-[22px] font-semibold text-[#3A332C] leading-tight block">
+                  {category.name}
+                </span>
+                {count !== null && (
+                  <span className="text-[10.5px] tracking-[0.1em] uppercase text-sage font-semibold mt-[3px] block">
+                    {count} {count === 1 ? 'treatment' : 'treatments'}
+                  </span>
+                )}
+              </div>
+
+              {/* sm+ (tablet/desktop): name inline */}
+              <span className="hidden sm:block font-serif text-[30px] font-semibold text-[#3A332C] leading-tight whitespace-nowrap">
+                {category.name}
+              </span>
+
+              {/* Blurb: tablet/desktop only, fills remaining space */}
+              <span className="hidden sm:block flex-1 text-[13.5px] text-[#8C8276] leading-snug">
+                {category.shortDescription}
+              </span>
+
+              {/* Count: tablet/desktop inline */}
+              {count !== null && (
+                <span className="hidden sm:block text-[11px] tracking-[0.12em] uppercase text-sage font-bold whitespace-nowrap shrink-0">
+                  {count} {count === 1 ? 'treatment' : 'treatments'}
+                </span>
+              )}
+
+              {/* Toggle indicator — aria-hidden since button already has aria-expanded */}
+              <span
+                aria-hidden="true"
+                className={
+                  isOpen
+                    ? 'flex items-center justify-center w-[30px] h-[30px] sm:w-8 sm:h-8 rounded-full bg-sage text-warm-white text-[21px] leading-none shrink-0 select-none'
+                    : 'flex items-center justify-center w-[30px] h-[30px] sm:w-8 sm:h-8 rounded-full border border-clay text-sage text-[19px] leading-none shrink-0 select-none'
+                }
+              >
+                {isOpen ? '−' : '+'}
+              </span>
+            </button>
+
+            {/* Expanded panel */}
+            {isOpen && (
+              <div
+                id={panelId}
+                role="region"
+                aria-labelledby={headerId}
+              >
+                {isLoading ? (
+                  <SkeletonRows />
+                ) : treatments && treatments.length > 0 ? (
+                  <div className="px-5 sm:px-7 pb-2 sm:pb-3">
+                    {treatments.map((item) => (
+                      <Link
+                        key={item.id}
+                        href={item.href}
+                        className="block sm:flex sm:justify-between sm:items-start sm:gap-6 py-4 sm:py-5 sm:px-2 border-t border-[rgba(74,64,56,0.1)] hover:bg-cream transition-colors duration-200"
+                      >
+                        {/* Left: name (+ mobile price), duration, description */}
+                        <div className="flex-1 min-w-0">
+                          {/* Mobile: name + price on same baseline row */}
+                          <div className="flex justify-between items-baseline gap-3 sm:block">
+                            <p className="font-serif text-[20px] sm:text-[23px] font-semibold text-[#3A332C] mb-0 sm:mb-[5px] leading-snug">
+                              {item.name}
+                            </p>
+                            {/* Price shown inline with name on mobile only */}
+                            <span className="sm:hidden font-serif text-[18px] text-sage font-semibold whitespace-nowrap shrink-0">
+                              {item.price}
+                            </span>
+                          </div>
+                          <p className="text-[10.5px] sm:text-[11.5px] tracking-[0.1em] sm:tracking-[0.12em] uppercase text-sage font-semibold mb-[6px] sm:mb-[9px]">
+                            {item.durationLabel}
+                          </p>
+                          <p className="text-[13px] sm:text-[14px] leading-[1.55] sm:leading-[1.6] text-taupe max-w-[460px]">
+                            {item.shortDescription}
+                          </p>
+                        </div>
+
+                        {/* Right: price (tablet/desktop) + "View details" (desktop only) */}
+                        <div className="hidden sm:flex flex-col items-end gap-1 shrink-0">
+                          <span className="font-serif text-[22px] text-sage font-semibold whitespace-nowrap">
+                            {item.price}
+                          </span>
+                          <span className="hidden lg:block text-[12px] font-bold tracking-[0.04em] text-cocoa whitespace-nowrap">
+                            View details →
+                          </span>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="px-5 sm:px-7 pb-5 text-[14px] text-taupe">
+                    No treatments found in this category.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/lib/cms/treatments.ts
+++ b/lib/cms/treatments.ts
@@ -151,7 +151,7 @@ function transformTreatmentMenuItem(
     name: row.title,
     slug: row.slug,
     shortDescription: row.description,
-    durationLabel: row.duration,
+    durationLabel: row.duration && !/min/i.test(row.duration) ? `${row.duration} min` : row.duration,
     price: row.price,
     href: `/treatments/${row.categorySlug}/${row.slug}`,
   };


### PR DESCRIPTION
## Summary

- Replaces the static treatment list with a hybrid accordion: categories rendered server-side, treatments lazy-loaded per panel via a server action
- Adds a fully responsive intro band (eyebrow, H1, lead copy, trust chips) matching the Sanctuary design spec across mobile/tablet/desktop
- Adds inline "Not sure which to choose?" CTA card at the bottom of the page
- Makes `BookingCtaBand` opt-in via `showCtaBand` prop on `MainLayout` — only the homepage renders it
- Fixes duration label to append " min" when Sanity stores a bare number (e.g. `"40"` → `"40 min"`)

## What Changed

| File | Change |
|------|--------|
| `app/treatments/page.tsx` | Full rebuild — intro band + accordion + inline CTA |
| `components/Sections/TreatmentsAccordion.tsx` | New hybrid accordion component |
| `app/treatments/actions.ts` | Server action for lazy per-panel treatment fetch |
| `components/Layout/MainLayout.tsx` | `showCtaBand` opt-in prop (default `false`) |
| `app/page.tsx` | Pass `showCtaBand` on homepage |
| `lib/cms/treatments.ts` | Duration label fix + `getTreatmentMenuByCategory` |

## Performance notes

- Treatment counts pre-computed in a single O(n) `reduce` pass instead of O(n·m) nested `filter`
- `TRUST_CHIPS` array hoisted to module level (no recreation per request)
- Minimal data serialised to client — `initialCounts` is `Record<string, number>` only

## Test Plan

- [ ] Treatments accordion opens/closes per category
- [ ] Skeleton rows show on first expand, treatments load correctly
- [ ] Duration label renders as "X min" not bare "X"
- [ ] Mobile (375px): stacked name+price, short lead copy, no breadcrumb/trust chips
- [ ] Tablet (768px): inline name+blurb+count, breadcrumb visible
- [ ] Desktop (1280px): "View details →" shown, full lead copy and trust chips
- [ ] "Not sure which to choose?" card visible above footer on treatments page
- [ ] `BookingCtaBand` visible on homepage, absent on all other pages
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)