### PR TITLE
feat(treatments): Sanctuary category page redesign + remove treatment counters

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -106,7 +106,7 @@ export default async function ContactPage({ params, searchParams }: ContactPageP
                                     <span className="font-serif text-sage text-[18px] w-5">✦</span>
                                     <div>
                                         <div className="font-sans text-[10.5px] tracking-[0.16em] uppercase text-warm-white/55 mb-[5px]">Address</div>
-                                        <a href="https://www.google.com/maps/search/Heavenly+Treatments+with+Hayleybell,+6+Easter+Softlaw+Farm+Cottage,+Kelso+TD5+8BJ" target="_blank" rel="noopener noreferrer" className="font-sans text-[15px] text-warm-white leading-[1.5] hover:text-clay transition-colors">6 Easter Softlaw Farm Cottage,<br />Kelso TD5 8BJ</a>
+                                        <a href="https://www.google.com/maps/search/Heavenly+Treatments+with+Hayleybell,+6+Easter+Softlaw+Farm+Cottage,+Kelso+TD5+8BJ" target="_blank" rel="noopener noreferrer" className="font-sans text-[15px] text-warm-white leading-normal hover:text-clay transition-colors">6 Easter Softlaw Farm Cottage,<br />Kelso TD5 8BJ</a>
                                     </div>
                                 </div>
                                 <div className="h-px bg-warm-white/12" />

--- a/app/treatments/[categorySlug]/[treatmentSlug]/page.tsx
+++ b/app/treatments/[categorySlug]/[treatmentSlug]/page.tsx
@@ -388,7 +388,7 @@ export default async function TreatmentDetailPage({ params }: Props) {
                 <Link
                   key={related.id}
                   href={getTreatmentPath(related)}
-                  className="bg-warm-white border border-cocoa/[0.08] rounded-[14px] hover:-translate-y-[5px] hover:shadow-[0_22px_44px_-28px_rgba(74,64,56,0.5)] transition-all duration-300
+                  className="bg-warm-white border border-cocoa/8 rounded-[14px] hover:-translate-y-[5px] hover:shadow-[0_22px_44px_-28px_rgba(74,64,56,0.5)] transition-all duration-300
                     flex items-center justify-between gap-4 p-5
                     md:flex-col md:items-start md:gap-2 md:p-7"
                 >

--- a/app/treatments/[categorySlug]/page.tsx
+++ b/app/treatments/[categorySlug]/page.tsx
@@ -2,7 +2,12 @@ import React, { cache } from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { getCategories, getTreatmentsByCategory, getTreatmentPath } from '@/lib/cms/treatments';
+import Image from 'next/image';
+import {
+  getCategories,
+  getTreatmentsByCategory,
+  getTreatmentPath,
+} from '@/lib/cms/treatments';
 import { TreatmentCategorySlug, TreatmentCategory } from '@/lib/data/treatments';
 import { MainLayout } from '@/components/Layout/MainLayout';
 import { contactInfo } from '@/lib/data/contactInfo';
@@ -10,7 +15,7 @@ import Script from 'next/script';
 import {
   generateHealthAndBeautyBusinessJsonLd,
   ContactInfo,
-  generateBreadcrumbJsonLd
+  generateBreadcrumbJsonLd,
 } from '@/lib/jsonLsUtils';
 import { config } from '@/lib/config';
 
@@ -42,10 +47,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || '';
   const siteName = 'Heavenly Treatments with Hayleybell';
   const pageTitle = `${categoryData.name} in Kelso | Heavenly Treatments Spa`;
-  const pageDescription = categoryData.description || categoryData.shortDescription ||
+  const pageDescription =
+    categoryData.description ||
+    categoryData.shortDescription ||
     `Professional ${categoryData.name.toLowerCase()} in Kelso, Scottish Borders. Book your session at Heavenly Treatments today.`;
   const canonicalUrl = `${BASE_URL}/treatments/${categorySlug}`;
-  const ogImageUrl = categoryData.image ? `${BASE_URL}${categoryData.image}` : `${BASE_URL}/images/logo.png`;
+  const ogImageUrl = categoryData.image
+    ? `${BASE_URL}${categoryData.image}`
+    : `${BASE_URL}/images/logo.png`;
 
   return {
     title: pageTitle,
@@ -74,7 +83,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export async function generateStaticParams(): Promise<{ categorySlug: string }[]> {
   const categories = await getCachedCategories();
-  return categories.map((category) => ({
+  return categories.map(category => ({
     categorySlug: category.slug,
   }));
 }
@@ -83,7 +92,6 @@ export default async function CategoryPage({ params }: Props) {
   const { categorySlug } = await params;
   const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || '';
 
-  // categorySlug is known from params — both fetches are independent, run in parallel.
   const [categories, treatments] = await Promise.all([
     getCachedCategories() as Promise<TreatmentCategory[]>,
     getTreatmentsByCategory(categorySlug as TreatmentCategorySlug),
@@ -108,6 +116,27 @@ export default async function CategoryPage({ params }: Props) {
   // Content is server-generated from trusted functions, not user input
   const jsonLdContent = JSON.stringify([businessJsonLd, breadcrumbJsonLd]);
 
+  // ── Stats computation ────────────────────────────────────────────────────
+  const extractNumeric = (str: string): number => {
+    const match = /\d+/.exec(str);
+    return match ? parseInt(match[0], 10) : 0;
+  };
+
+  const prices = treatments.map(t => extractNumeric(t.price)).filter(p => p > 0);
+  const priceFrom = prices.length > 0 ? `from £${Math.min(...prices)}` : null;
+
+  const durations = treatments.map(t => extractNumeric(t.duration)).filter(d => d > 0);
+  const minDur = durations.length > 0 ? Math.min(...durations) : null;
+  const maxDur = durations.length > 0 ? Math.max(...durations) : null;
+  const durationRange =
+    minDur !== null && maxDur !== null
+      ? minDur === maxDur
+        ? `${minDur} min`
+        : `${minDur}–${maxDur} min`
+      : null;
+
+  const otherCategories = categories.filter(cat => cat.slug !== categorySlug);
+
   return (
     <MainLayout>
       <Script
@@ -116,95 +145,309 @@ export default async function CategoryPage({ params }: Props) {
         dangerouslySetInnerHTML={{ __html: jsonLdContent }}
       />
 
-      {/* ── Intro band ────────────────────────────────────────────────── */}
+      {/* ── SECTION 1: Breadcrumb ─────────────────────────────────────────── */}
       <div className="border-b bg-stone border-cocoa/10">
-        <div className="max-w-[1180px] mx-auto pt-[30px] pb-7 px-[22px] md:pt-[62px] md:pb-[56px] md:px-8">
+        <div className="max-w-[1180px] mx-auto px-[22px] sm:px-8">
 
-          {/* Breadcrumb */}
-          <nav aria-label="Breadcrumb" className="hidden sm:flex items-center mb-[22px] font-sans text-[12.5px] text-[#8C8276]">
-            <Link href="/" className="font-semibold transition-opacity text-sage hover:opacity-80">
+          {/* Mobile: back link */}
+          <Link
+            href="/treatments"
+            className="sm:hidden flex items-center gap-2 py-[14px] font-sans text-[12.5px] font-semibold text-sage"
+          >
+            <span aria-hidden="true">←</span>
+            Treatments
+          </Link>
+
+          {/* Desktop: full breadcrumb */}
+          <nav
+            aria-label="Breadcrumb"
+            className="hidden sm:flex items-center py-[14px] font-sans text-[12.5px] text-[#8C8276]"
+          >
+            <Link
+              href="/"
+              className="font-semibold transition-opacity text-sage hover:opacity-80"
+            >
               Home
             </Link>
-            <span className="mx-2 text-clay" aria-hidden="true">/</span>
-            <Link href="/treatments" className="font-semibold transition-opacity text-sage hover:opacity-80">
+            <span className="mx-2 text-clay" aria-hidden="true">
+              /
+            </span>
+            <Link
+              href="/treatments"
+              className="font-semibold transition-opacity text-sage hover:opacity-80"
+            >
               Treatments
             </Link>
-            <span className="mx-2 text-clay" aria-hidden="true">/</span>
+            <span className="mx-2 text-clay" aria-hidden="true">
+              /
+            </span>
             <span>{categoryData.name}</span>
           </nav>
+        </div>
+      </div>
 
-          {/* Eyebrow */}
-          <div className="flex items-center gap-[10px] sm:gap-3 mb-[14px] sm:mb-[18px]" aria-hidden="true">
-            <span className="w-[22px] sm:w-7 h-px bg-clay shrink-0" />
-            <span className="font-sans text-[10.5px] sm:text-[12px] tracking-[0.2em] sm:tracking-[0.22em] uppercase text-sage font-semibold">
+      {/* ── SECTION 2: Hero ───────────────────────────────────────────────── */}
+      <div className="bg-cream">
+        <div className="max-w-[1180px] mx-auto px-[22px] sm:px-[30px] lg:px-[32px] pt-[32px] sm:pt-[40px] lg:pt-[56px] pb-[40px] sm:pb-[24px] lg:pb-[20px] flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-[40px] lg:gap-[60px]">
+
+          {/* ── Left: text column ─────────────────────────────────────────── */}
+          <div>
+            {/* Eyebrow */}
+            <div
+              className="flex items-center gap-[10px] sm:gap-3 mb-[14px] sm:mb-[18px]"
+              aria-hidden="true"
+            >
+              <span className="w-[22px] sm:w-7 h-px bg-clay shrink-0" />
+              <span className="font-sans text-[10.5px] sm:text-[12px] tracking-[0.2em] sm:tracking-[0.22em] uppercase text-sage font-semibold">
+                {categoryData.name}
+              </span>
+            </div>
+
+            {/* H1 */}
+            <h1 className="font-serif text-[40px] sm:text-[50px] lg:text-[64px] font-medium text-[#3A332C] tracking-[-0.01em] leading-[1.02] mb-3 sm:mb-5">
               {categoryData.name}
-            </span>
+            </h1>
+
+            {/* Intro paragraph */}
+            {(categoryData.description || categoryData.shortDescription) && (
+              <p className="font-sans text-[15px] sm:text-[17px] leading-[1.75] text-taupe max-w-[480px] mb-[20px] sm:mb-[30px]">
+                {categoryData.description || categoryData.shortDescription}
+              </p>
+            )}
+
+            {/* Stats row */}
+            {(priceFrom || durationRange) && (
+              <div
+                className="flex items-center gap-[14px] sm:gap-6 border-t border-b py-[16px] sm:py-[20px] mb-[24px] sm:mb-[30px]"
+                style={{ borderColor: 'rgba(74,64,56,0.12)' }}
+              >
+                {/* Price */}
+                {priceFrom && (
+                  <div className="flex flex-col">
+                    <span className="font-sans text-[9.5px] sm:text-[11px] uppercase tracking-[0.16em] text-[#8C8276] mb-[3px] sm:mb-[4px]">
+                      Price
+                    </span>
+                    <span className="font-serif text-[17px] sm:text-[19px] lg:text-[23px] text-sage font-semibold">
+                      {priceFrom}
+                    </span>
+                  </div>
+                )}
+
+                {/* Duration */}
+                {durationRange && (
+                  <>
+                    {priceFrom && (
+                      <div
+                        className="w-px h-[32px] sm:h-[38px] shrink-0"
+                        style={{ backgroundColor: 'rgba(74,64,56,0.14)' }}
+                      />
+                    )}
+                    <div className="flex flex-col">
+                      <span className="font-sans text-[9.5px] sm:text-[11px] uppercase tracking-[0.16em] text-[#8C8276] mb-[3px] sm:mb-[4px]">
+                        Duration
+                      </span>
+                      <span className="font-serif text-[17px] sm:text-[19px] lg:text-[23px] text-[#3A332C] font-semibold">
+                        {durationRange}
+                      </span>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* CTAs — desktop / tablet only (spec: no CTAs in mobile hero) */}
+            <div className="hidden gap-6 items-center sm:flex">
+              <Link
+                href="/contact"
+                className="inline-block font-sans font-semibold text-[14.5px] bg-sage text-warm-white px-[34px] py-4 rounded-full hover:opacity-90 transition-opacity"
+                style={{ boxShadow: '0 12px 28px -12px rgba(110,126,96,0.7)' }}
+              >
+                Book a session
+              </Link>
+              <Link
+                href="/treatments"
+                className="font-sans font-semibold text-[14.5px] text-[#4A4038] border-b-[1.5px] border-clay pb-[3px] hover:opacity-80 transition-opacity"
+              >
+                All treatments &rarr;
+              </Link>
+            </div>
           </div>
 
-          {/* H1 — mobile mb 12px, desktop mb 20px (design spec) */}
-          <h1 className="font-serif text-[36px] sm:text-[46px] lg:text-[60px] font-medium text-[#3A332C] tracking-[-0.01em] leading-[1.04] max-w-[720px] mb-3 sm:mb-5">
-            {categoryData.name}
-          </h1>
+          {/* ── Right: image column ───────────────────────────────────────── */}
+          <div className="relative mt-[24px] sm:mt-0">
+            {/* Decorative circle — tablet / desktop only */}
+            <div className="hidden sm:block absolute -top-[18px] -right-[18px] sm:w-[90px] sm:h-[90px] lg:w-[110px] lg:h-[110px] border border-clay rounded-full opacity-50 z-2" />
 
-          {/* Lead — 14.5px mobile, 16.5px desktop */}
-          {(categoryData.description || categoryData.shortDescription) && (
-            <p className="font-sans text-[14.5px] sm:text-[16.5px] leading-[1.7] text-taupe max-w-[560px] mb-6">
-              {categoryData.description || categoryData.shortDescription}
+            {/* Image container with pill-top border-radius */}
+            <div
+              className="relative z-1 w-full overflow-hidden h-[240px] sm:h-[380px] lg:h-[520px] rounded-t-[140px] rounded-b-[14px] sm:rounded-t-[190px] sm:rounded-b-[12px] lg:rounded-t-[240px] lg:rounded-b-[14px]"
+              style={{ boxShadow: '0 30px 60px -30px rgba(74,64,56,0.45)' }}
+            >
+              {categoryData.image ? (
+                <Image
+                  src={categoryData.image}
+                  alt={`${categoryData.name} treatments`}
+                  fill
+                  style={{ objectFit: 'cover' }}
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 45vw"
+                  priority
+                />
+              ) : (
+                <div className="w-full h-full bg-stone" />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── SECTION 3: Treatment list ─────────────────────────────────────── */}
+      <div className="bg-cream pt-[50px] sm:pt-[60px] pb-[40px] sm:pb-[50px]">
+        <div className="max-w-[1180px] mx-auto px-[22px] sm:px-8">
+
+          {/* Heading row */}
+          <div className="mb-[20px] sm:mb-[24px]">
+            <h2 className="font-serif text-[28px] sm:text-[34px] font-medium text-[#3A332C]">
+              The {categoryData.name} menu
+            </h2>
+          </div>
+
+          {/* Mobile: individual cards */}
+          <div className="sm:hidden flex flex-col gap-[10px] mb-[40px]">
+            {treatments.length > 0 ? (
+              treatments.map(treatment => (
+                <Link
+                  key={treatment.id}
+                  href={getTreatmentPath(treatment)}
+                  className="block bg-[#FAF6F0] border border-cocoa/8 rounded-2xl p-[18px_20px] hover:bg-cream transition-colors"
+                >
+                  <div className="flex justify-between items-start mb-[6px]">
+                    <h3 className="font-serif text-[19px] font-semibold text-[#3A332C] leading-tight mr-3">
+                      {treatment.title}
+                    </h3>
+                    <span className="font-serif text-[19px] text-sage font-semibold whitespace-nowrap shrink-0">
+                      {treatment.price}
+                    </span>
+                  </div>
+                  <p className="font-sans text-[10px] uppercase tracking-[0.12em] text-sage font-semibold mb-[6px]">
+                    {treatment.duration}
+                  </p>
+                  <p className="font-sans text-[13px] leading-[1.6] text-taupe">
+                    {treatment.description}
+                  </p>
+                </Link>
+              ))
+            ) : (
+              <p className="font-sans text-[16px] text-taupe text-center py-12">
+                No treatments found in this category yet.
+              </p>
+            )}
+          </div>
+
+          {/* Tablet + Desktop: unified list container */}
+          {treatments.length > 0 ? (
+            <div className="hidden sm:block bg-[#FAF6F0] border border-cocoa/8 rounded-2xl px-7 pb-3 pt-[6px] mb-[50px] sm:mb-[60px]">
+              {treatments.map(treatment => (
+                <Link
+                  key={treatment.id}
+                  href={getTreatmentPath(treatment)}
+                  className="flex justify-between items-start gap-6 py-[22px] px-2 border-t border-cocoa/10 first:border-t-0 hover:bg-cream transition-colors rounded-sm"
+                >
+                  {/* Left: name, duration, description */}
+                  <div className="min-w-0">
+                    <h3 className="font-serif text-[21px] lg:text-[23px] font-semibold text-[#3A332C] mb-[5px] leading-tight">
+                      {treatment.title}
+                    </h3>
+                    <p className="font-sans text-[11.5px] uppercase tracking-[0.12em] text-sage font-semibold mb-[9px]">
+                      {treatment.duration}
+                    </p>
+                    <p className="font-sans text-[14px] leading-[1.6] text-taupe max-w-[440px] lg:max-w-[520px]">
+                      {treatment.description}
+                    </p>
+                  </div>
+
+                  {/* Right: price + link cue */}
+                  <div className="text-right shrink-0">
+                    <p className="font-serif text-[22px] text-sage font-semibold whitespace-nowrap">
+                      {treatment.price}
+                    </p>
+                    <p className="font-sans text-[12px] font-bold tracking-[0.04em] text-cocoa mt-1">
+                      View details &rarr;
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <p className="hidden sm:block font-sans text-[16px] text-taupe text-center py-12 mb-[50px]">
+              No treatments found in this category yet.
             </p>
           )}
         </div>
       </div>
 
-      {/* ── Treatments list + CTA ──────────────────────────────────────── */}
-      <div className="bg-cream pt-[70px] pb-[30px]">
-        <div className="max-w-[1180px] mx-auto px-[22px] sm:px-8">
+      {/* ── SECTION 4: Explore other collections ─────────────────────────── */}
+      {otherCategories.length > 0 && (
+        <div className="bg-stone py-[50px] sm:py-[60px]">
+          <div className="max-w-[1180px] mx-auto px-[22px] sm:px-8">
 
-          {treatments.length > 0 ? (
-            <ul className="mb-[60px]">
-              {treatments.map((treatment) => (
-                <li key={treatment.id} className="border-t border-cocoa/10 first:border-t-0">
-                  <Link
-                    href={getTreatmentPath(treatment)}
-                    className="flex justify-between items-start gap-6 py-5 px-2 hover:bg-[#F3EEE7] transition-colors rounded-sm"
-                  >
-                    {/* Left: name, duration, description */}
-                    <div className="min-w-0">
-                      <p className="font-serif text-[23px] font-semibold text-[#3A332C] mb-[5px] leading-tight">
-                        {treatment.title}
-                      </p>
-                      <p className="font-sans text-[11.5px] tracking-[0.12em] uppercase text-sage font-semibold mb-[9px]">
-                        {treatment.duration}
-                      </p>
-                      <p className="font-sans text-[14px] leading-[1.6] text-taupe max-w-[460px]">
-                        {treatment.description}
-                      </p>
-                    </div>
+            {/* Eyebrow */}
+            <div className="flex items-center gap-3 mb-[24px] sm:mb-[30px]">
+              <span className="w-7 h-px bg-clay shrink-0" />
+              <span className="font-sans text-[12px] uppercase text-sage font-semibold tracking-[0.22em]">
+                Explore other collections
+              </span>
+            </div>
 
-                    {/* Right: price + link cue */}
-                    <div className="text-right shrink-0">
-                      <p className="font-serif text-[22px] text-sage font-semibold whitespace-nowrap">
-                        {treatment.price}
-                      </p>
-                      <p className="font-sans text-[12px] font-bold tracking-[0.04em] text-cocoa mt-1">
-                        View details &rarr;
-                      </p>
-                    </div>
-                  </Link>
-                </li>
+            {/* Mobile: simple vertical stack */}
+            <div className="sm:hidden flex flex-col gap-[10px]">
+              {otherCategories.map(cat => (
+                <Link
+                  key={cat.id}
+                  href={`/treatments/${cat.slug}`}
+                  className="flex items-center gap-[14px] bg-[#FAF6F0] border border-cocoa/8 rounded-2xl p-[16px_20px] hover:bg-cream transition-colors"
+                >
+                  <p className="font-serif text-[21px] font-semibold text-[#3A332C] leading-tight flex-1 min-w-0">
+                    {cat.name}
+                  </p>
+                  <span className="font-sans font-bold text-sage text-[13px] tracking-[0.02em] shrink-0">
+                    &rarr;
+                  </span>
+                </Link>
               ))}
-            </ul>
-          ) : (
-            <p className="font-sans text-[16px] text-taupe text-center py-12">
-              No treatments found in this category yet.
-            </p>
-          )}
+            </div>
 
-          {/* "Not sure which to choose?" CTA card */}
-          <div className="bg-sage rounded-[20px] p-[54px] text-center mt-4 mb-[90px]">
-            <h2 className="font-serif text-[40px] font-medium text-warm-white mb-[14px] leading-tight">
+            {/* Tablet + Desktop: 2-col → 4-col grid */}
+            <div className="hidden sm:grid sm:grid-cols-2 lg:grid-cols-4 sm:gap-[14px] lg:gap-[18px]">
+              {otherCategories.map(cat => (
+                <Link
+                  key={cat.id}
+                  href={`/treatments/${cat.slug}`}
+                  className="bg-[#FAF6F0] border border-cocoa/8 rounded-2xl p-[26px] flex flex-col gap-[10px] hover:shadow-lg hover:-translate-y-1 transition-all"
+                >
+                  <h3 className="font-serif sm:text-[21px] lg:text-[25px] font-semibold text-[#3A332C] leading-tight">
+                    {cat.name}
+                  </h3>
+                  <p className="font-sans text-[13.5px] leading-[1.6] text-taupe flex-1">
+                    {cat.shortDescription || cat.description}
+                  </p>
+                  <p className="font-sans font-bold text-sage text-[13px] tracking-[0.02em]">
+                    Discover &rarr;
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── SECTION 5: Green CTA block ───────────────────────────────────── */}
+      <div className="bg-cream py-[60px] sm:py-[80px] sm:pb-[90px]">
+        <div className="max-w-[1180px] mx-auto px-[22px] sm:px-8">
+          <div className="bg-sage rounded-[20px] p-[40px_22px] sm:p-[54px] text-center">
+            <h2 className="font-serif text-[28px] sm:text-[40px] font-medium text-warm-white mb-[14px] leading-tight">
               Not sure which to choose?
             </h2>
-            <p className="font-sans text-[16px] leading-[1.7] text-warm-white/88 max-w-[460px] mx-auto mb-7">
+            <p className="font-sans text-[13.5px] sm:text-[16px] leading-[1.7] text-warm-white/88 max-w-[470px] mx-auto mb-7">
               Tell me how you&apos;d like to feel and I&apos;ll help you find the perfect treatment.
               Appointments Mon&ndash;Sun, 10am&ndash;5pm.
             </p>
@@ -215,7 +458,6 @@ export default async function CategoryPage({ params }: Props) {
               Contact me &amp; book
             </Link>
           </div>
-
         </div>
       </div>
     </MainLayout>

--- a/app/treatments/page.tsx
+++ b/app/treatments/page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { getCategories, getTreatmentCountsByCategory } from '@/lib/cms/treatments';
+import { getCategories } from '@/lib/cms/treatments';
 import { type TreatmentCategory } from '@/lib/data/treatments';
 import { MainLayout } from '@/components/Layout/MainLayout';
 import TreatmentsAccordion from '@/components/Sections/TreatmentsAccordion';
@@ -61,10 +61,7 @@ export default async function TreatmentsPage() {
   const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || '';
 
   // Categories are fetched server-side; treatments load lazily per accordion panel
-  const [categories, initialCounts] = await Promise.all([
-    getCategories() as Promise<TreatmentCategory[]>,
-    getTreatmentCountsByCategory(),
-  ]);
+  const categories = (await getCategories()) as TreatmentCategory[];
 
   // Generate JSON-LD structured data (server-generated, trusted content)
   const businessJsonLd = generateHealthAndBeautyBusinessJsonLd(contactInfo as ContactInfo);
@@ -88,21 +85,21 @@ export default async function TreatmentsPage() {
       {jsonLdScript}
 
       {/* ── Intro band ────────────────────────────────────────────────── */}
-      <div className="bg-stone border-b border-cocoa/10">
+      <div className="border-b bg-stone border-cocoa/10">
         <div className="max-w-[1180px] mx-auto pt-[30px] pb-7 px-[22px] md:pt-[62px] md:pb-[56px] md:px-8">
 
           {/* Breadcrumb */}
           <nav aria-label="Breadcrumb" className="hidden sm:flex items-center mb-[22px] font-sans text-[12.5px]">
-            <Link href="/" className="text-sage font-semibold hover:opacity-80 transition-opacity">
+            <Link href="/" className="font-semibold transition-opacity text-sage hover:opacity-80">
               Home
             </Link>
-            <span className="text-clay mx-2" aria-hidden="true">/</span>
+            <span className="mx-2 text-clay" aria-hidden="true">/</span>
             <span className="text-[#8C8276]">Treatments</span>
           </nav>
 
           {/* Eyebrow */}
           <div className="flex items-center gap-[10px] sm:gap-3 mb-[14px] sm:mb-[18px]" aria-hidden="true">
-            <span className="w-[22px] sm:w-7 h-px bg-clay flex-shrink-0" />
+            <span className="w-[22px] sm:w-7 h-px bg-clay shrink-0" />
             <span className="font-sans text-[10.5px] sm:text-[12px] tracking-[0.2em] sm:tracking-[0.22em] uppercase text-sage font-semibold">
               The Treatment Menu
             </span>
@@ -139,7 +136,7 @@ export default async function TreatmentsPage() {
 
       {/* ── Accordion + CTA card on cream background ─────────────────── */}
       <div className="bg-cream">
-        <TreatmentsAccordion categories={categories} initialCounts={initialCounts} />
+        <TreatmentsAccordion categories={categories} />
 
         {/* "Not sure which to choose?" card — inline, per design */}
         <div className="max-w-[1180px] mx-auto px-[18px] sm:px-8 pt-4 pb-8 sm:pt-0 sm:pb-[90px]">

--- a/components/Layout/BookingCtaBand.tsx
+++ b/components/Layout/BookingCtaBand.tsx
@@ -41,27 +41,27 @@ export default function BookingCtaBand({ className }: BookingCtaBandProps) {
         </div>
 
         {/* Frosted-glass contact card — desktop only */}
-        <div className="hidden flex-col gap-[22px] rounded-[18px] border border-warm-white/[22%] bg-warm-white/10 p-9 lg:flex">
+        <div className="hidden flex-col gap-[22px] rounded-[18px] border border-warm-white/22 bg-warm-white/10 p-9 lg:flex">
           {/* Address */}
           <div className="flex items-start gap-[14px]">
-            <span className="w-[22px] flex-shrink-0 font-serif text-[18px] leading-none text-warm-white">
+            <span className="w-[22px] shrink-0 font-serif text-[18px] leading-none text-warm-white">
               ✦
             </span>
             <div>
               <p className="mb-1 text-[11px] uppercase tracking-[0.16em] text-warm-white/65">
                 Find me
               </p>
-              <address className="not-italic text-[15px] leading-[1.5] text-warm-white">
+              <address className="not-italic text-[15px] leading-normal text-warm-white">
                 {fullAddress}
               </address>
             </div>
           </div>
 
-          <hr className="border-warm-white/[18%]" />
+          <hr className="border-warm-white/18" />
 
           {/* Phone */}
           <div className="flex items-start gap-[14px]">
-            <span className="w-[22px] flex-shrink-0 font-serif text-[18px] leading-none text-warm-white">
+            <span className="w-[22px] shrink-0 font-serif text-[18px] leading-none text-warm-white">
               ✦
             </span>
             <div>
@@ -70,18 +70,18 @@ export default function BookingCtaBand({ className }: BookingCtaBandProps) {
               </p>
               <a
                 href={telHref}
-                className="text-[15px] leading-[1.5] text-warm-white transition-colors hover:text-cream"
+                className="text-[15px] leading-normal text-warm-white transition-colors hover:text-cream"
               >
                 {phone}
               </a>
             </div>
           </div>
 
-          <hr className="border-warm-white/[18%]" />
+          <hr className="border-warm-white/18" />
 
           {/* Email */}
           <div className="flex items-start gap-[14px]">
-            <span className="w-[22px] flex-shrink-0 font-serif text-[18px] leading-none text-warm-white">
+            <span className="w-[22px] shrink-0 font-serif text-[18px] leading-none text-warm-white">
               ✦
             </span>
             <div>
@@ -90,7 +90,7 @@ export default function BookingCtaBand({ className }: BookingCtaBandProps) {
               </p>
               <a
                 href={`mailto:${email}`}
-                className="break-all text-[15px] leading-[1.5] text-warm-white transition-colors hover:text-cream"
+                className="break-all text-[15px] leading-normal text-warm-white transition-colors hover:text-cream"
               >
                 {email}
               </a>

--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -44,11 +44,11 @@ export default function Footer() {
       {/* ── Mobile footer (<640px) — centered brand + nav row + copyright ── */}
       {/* aria-hidden: desktop section (always in DOM) is the accessible footer;
           mobile users navigate via the hamburger overlay */}
-      <div aria-hidden="true" className="flex flex-col items-center gap-5 px-6 py-12 text-center sm:hidden">
+      <div aria-hidden="true" className="flex flex-col gap-5 items-center px-6 py-12 text-center sm:hidden">
         <h3 className="font-serif text-[25px] font-semibold text-cream">
           Heavenly Treatments
         </h3>
-        <div className="flex flex-wrap justify-center gap-x-6 gap-y-2">
+        <div className="flex flex-wrap gap-y-2 gap-x-6 justify-center">
           {mobileNavLinks.map((item) => (
             <Link
               key={item.href}
@@ -67,7 +67,7 @@ export default function Footer() {
       {/* ── Tablet footer (640–1023px) — 2-column brand + connect ── */}
       <div aria-hidden="true" className="hidden sm:block lg:hidden">
         <div className="mx-auto max-w-7xl px-[30px] pt-10 pb-7">
-          <div className="grid grid-cols-[1.4fr_1fr] gap-[30px] border-b border-white/[12%] pb-7">
+          <div className="grid grid-cols-[1.4fr_1fr] gap-[30px] border-b border-white/12 pb-7">
             {/* Brand */}
             <div>
               <h3 className="mb-[10px] font-serif text-[22px] font-semibold text-cream">
@@ -120,7 +120,7 @@ export default function Footer() {
       {/* ── Desktop footer (≥1024px) — 3-column grid ── */}
       <div className="hidden lg:block">
         <div className="mx-auto max-w-7xl px-6 pt-[70px] pb-9 lg:px-8">
-          <div className="grid grid-cols-[1.5fr_1fr_1fr] gap-[48px] border-b border-white/[12%] pb-[50px]">
+          <div className="grid grid-cols-[1.5fr_1fr_1fr] gap-[48px] border-b border-white/12 pb-[50px]">
             {/* Brand */}
             <div className="space-y-[14px]">
               <h3 className="font-serif text-[25px] font-semibold leading-tight text-cream">
@@ -187,7 +187,7 @@ export default function Footer() {
             </div>
           </div>
 
-          <div className="flex flex-col items-center justify-between gap-3 pt-6 sm:flex-row">
+          <div className="flex flex-col gap-3 justify-between items-center pt-6 sm:flex-row">
             <p className="text-[12.5px] text-cream/40">
               © {year} Heavenly Treatments. All rights reserved.
             </p>

--- a/components/Layout/Navbar.tsx
+++ b/components/Layout/Navbar.tsx
@@ -74,7 +74,7 @@ export default function Navbar() {
   const closeOverlay = () => setIsOverlayOpen(false);
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-cocoa/[8%] bg-cream/[86%] backdrop-blur-[10px] supports-backdrop-filter:bg-cream/[80%]">
+    <header className="sticky top-0 z-50 w-full border-b border-cocoa/8 bg-cream/86 backdrop-blur-[10px] supports-backdrop-filter:bg-cream/80">
       <div className="mx-auto flex h-[60px] w-full max-w-7xl items-center justify-between px-4 sm:h-[73px] sm:px-6 lg:px-8">
         <Wordmark />
 
@@ -117,7 +117,7 @@ export default function Navbar() {
               <button
                 type="button"
                 aria-label="Open menu"
-                className="inline-flex size-12 items-center justify-center rounded-full text-espresso transition-colors hover:bg-stone focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage"
+                className="inline-flex justify-center items-center rounded-full transition-colors size-12 text-espresso hover:bg-stone focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage"
               >
                 <Menu className="size-6" aria-hidden="true" />
               </button>
@@ -130,7 +130,7 @@ export default function Navbar() {
                 aria-describedby={undefined}
               >
                 {/* Header row */}
-                <div className="mb-10 flex items-center justify-between">
+                <div className="flex justify-between items-center mb-10">
                   <Dialog.Title className="font-serif text-[22px] font-semibold text-cream">
                     Menu
                   </Dialog.Title>
@@ -156,7 +156,7 @@ export default function Navbar() {
                         onClick={closeOverlay}
                         aria-current={active ? 'page' : undefined}
                         className={cn(
-                          'flex min-h-[48px] w-full items-center border-b border-white/[12%] py-3 font-serif text-[38px] font-medium leading-tight transition-colors hover:text-clay',
+                          'flex items-center py-3 w-full font-serif font-medium leading-tight border-b transition-colors min-h-[48px] border-white/12 text-[38px] hover:text-clay',
                           active ? 'text-clay' : 'text-cream',
                         )}
                       >
@@ -167,7 +167,7 @@ export default function Navbar() {
                 </nav>
 
                 {/* Contact info — pushed to bottom */}
-                <div className="mt-auto flex flex-col gap-2">
+                <div className="flex flex-col gap-2 mt-auto">
                   <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sage">
                     Get in touch
                   </span>

--- a/components/Sections/AboutHero.tsx
+++ b/components/Sections/AboutHero.tsx
@@ -89,7 +89,7 @@ export default function AboutHero() {
               aria-hidden="true"
             />
             <div
-              className="relative aspect-[4/5] overflow-hidden shadow-[0_30px_60px_-30px_rgba(74,64,56,0.45)]"
+              className="relative aspect-4/5 overflow-hidden shadow-[0_30px_60px_-30px_rgba(74,64,56,0.45)]"
               style={{ borderRadius: '260px 260px 14px 14px' }}
             >
               <OptimizedImage

--- a/components/Sections/AboutPullQuote.tsx
+++ b/components/Sections/AboutPullQuote.tsx
@@ -4,7 +4,7 @@ export default function AboutPullQuote() {
       <div className="max-w-[900px] mx-auto px-8 text-center">
 
         <div
-          className="font-serif text-[60px] text-clay leading-[0] inline-block h-[30px] mb-6"
+          className="font-serif text-[60px] text-clay leading-0 inline-block h-[30px] mb-6"
           aria-hidden="true"
         >
           &ldquo;

--- a/components/Sections/BookingCtaBand.tsx
+++ b/components/Sections/BookingCtaBand.tsx
@@ -51,7 +51,7 @@ export default function BookingCtaBand() {
                 >
                   Find me
                 </p>
-                <p className="font-sans text-[15px] text-warm-white leading-[1.5] mb-0">
+                <p className="font-sans text-[15px] text-warm-white leading-normal mb-0">
                   6 Easter Softlaw Farm Cottage, Kelso TD5 8BJ
                 </p>
               </div>
@@ -76,7 +76,7 @@ export default function BookingCtaBand() {
                 >
                   Call or message
                 </p>
-                <p className="font-sans text-[15px] text-warm-white leading-[1.5] mb-0">
+                <p className="font-sans text-[15px] text-warm-white leading-normal mb-0">
                   07960 315 337
                 </p>
               </div>
@@ -101,7 +101,7 @@ export default function BookingCtaBand() {
                 >
                   Email
                 </p>
-                <p className="font-sans text-[15px] text-warm-white leading-[1.5] mb-0">
+                <p className="font-sans text-[15px] text-warm-white leading-normal mb-0">
                   hayley@heavenly-treatments.co.uk
                 </p>
               </div>

--- a/components/Sections/Introduction.tsx
+++ b/components/Sections/Introduction.tsx
@@ -5,14 +5,14 @@ export default function IntroductionSection() {
   return (
     <section
       aria-labelledby="about-heading"
-      className="hidden lg:block py-20 xl:py-28 bg-cream"
+      className="hidden py-20 lg:block xl:py-28 bg-cream"
     >
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center gap-16 xl:gap-20">
+      <div className="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+        <div className="flex gap-16 items-center xl:gap-20">
 
           {/* Left: portrait image with overlapping badge */}
           <div className="flex-1 relative max-w-[420px]">
-            <div className="relative rounded-2xl overflow-hidden aspect-[3/4]">
+            <div className="overflow-hidden relative rounded-2xl aspect-3/4">
               <Image
                 src="/images/about/owner-of-heavenly-treatments.jpg"
                 alt="Hayley, owner and lead therapist at Heavenly Treatments in Kelso"
@@ -23,7 +23,7 @@ export default function IntroductionSection() {
             </div>
             {/* Badge overlaps the bottom-right corner of the image */}
             <div className="absolute bottom-[-16px] right-[-16px] bg-sage rounded-2xl px-5 py-4 text-center min-w-[110px]">
-              <p className="font-serif text-warm-white text-2xl leading-none mb-0">5★</p>
+              <p className="mb-0 font-serif text-2xl leading-none text-warm-white">5★</p>
               <p className="font-sans text-warm-white text-[10px] uppercase tracking-widest mt-1 mb-0">
                 Spa Trained
               </p>
@@ -31,10 +31,10 @@ export default function IntroductionSection() {
           </div>
 
           {/* Right: bio copy */}
-          <div className="flex-1 flex flex-col gap-6">
+          <div className="flex flex-col flex-1 gap-6">
 
             {/* Eyebrow */}
-            <div className="flex items-center gap-3">
+            <div className="flex gap-3 items-center">
               <div className="w-8 h-px bg-clay" />
               <span className="font-sans text-[11px] uppercase tracking-[0.24em] text-taupe">
                 Welcome
@@ -49,12 +49,12 @@ export default function IntroductionSection() {
             </h2>
 
             <div className="flex flex-col gap-4">
-              <p className="font-sans text-base text-cocoa leading-relaxed mb-0">
+              <p className="mb-0 font-sans text-base leading-relaxed text-cocoa">
                 After years working in five-star establishments, I&apos;ve brought that experience
                 to my own treatment room. I&apos;ve always had a passion for wellness and skincare,
                 and have carefully curated a menu of all my favourite treatments.
               </p>
-              <p className="font-sans text-base text-cocoa leading-relaxed mb-0">
+              <p className="mb-0 font-sans text-base leading-relaxed text-cocoa">
                 Each appointment begins with a brief consultation, so every treatment is
                 aligned with exactly what you need.
               </p>
@@ -62,7 +62,7 @@ export default function IntroductionSection() {
 
             <Link
               href="/about"
-              className="font-sans text-sm font-semibold text-espresso underline underline-offset-4 hover:opacity-70 transition-opacity w-fit"
+              className="font-sans text-sm font-semibold underline transition-opacity text-espresso underline-offset-4 hover:opacity-70 w-fit"
             >
               More about me →
             </Link>

--- a/components/Sections/MainHeader.tsx
+++ b/components/Sections/MainHeader.tsx
@@ -7,8 +7,8 @@ import { BookingButton } from '@/components/BookingButton';
 
 const TrustRowContent: React.FC = () => (
   <>
-    <div className="flex flex-col items-start gap-1">
-      <span className="text-xl text-sage leading-none" aria-label="Five star rating">★★★★★</span>
+    <div className="flex flex-col gap-1 items-start">
+      <span className="text-xl leading-none text-sage" aria-label="Five star rating">★★★★★</span>
       <span className="font-sans text-xs text-taupe">Loved by local clients</span>
     </div>
     <span className="w-px h-8 bg-clay/40" aria-hidden="true" />
@@ -23,20 +23,20 @@ const MainHeader: React.FC = () => {
   return (
     <section
       aria-labelledby="hero-heading"
-      className="pt-8 pb-16 md:pt-12 md:pb-20 lg:py-24 bg-cream overflow-hidden md:overflow-visible"
+      className="overflow-hidden pt-8 pb-16 md:pt-12 md:pb-20 lg:py-24 bg-cream md:overflow-visible"
     >
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div className="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
         {/*
           Mobile:  flex-col  → content first, image second, trust row third
           Desktop: flex-row  → left column (content+trust) | right column (image)
         */}
-        <div className="flex flex-col md:flex-row md:items-center gap-10 md:gap-16">
+        <div className="flex flex-col gap-10 md:flex-row md:items-center md:gap-16">
 
           {/* ── Left column: content ─────────────────────────────────── */}
           <div className="flex-1 md:flex-[1.2] flex flex-col gap-6 text-left">
 
             {/* Eyebrow */}
-            <div className="flex items-center gap-3" aria-hidden="true">
+            <div className="flex gap-3 items-center" aria-hidden="true">
               <div className="w-8 h-px bg-clay" />
               <span className="font-sans text-[11px] uppercase tracking-[0.24em] text-taupe">
                 Kelso · Scottish Borders
@@ -59,23 +59,23 @@ const MainHeader: React.FC = () => {
             </p>
 
             {/* CTA row */}
-            <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
               <BookingButton
                 context="hero"
-                className="rounded-full px-8 py-3 h-auto font-sans font-semibold text-sm transition-colors w-full sm:w-auto"
+                className="px-8 py-3 w-full h-auto font-sans text-sm font-semibold rounded-full transition-colors sm:w-auto"
               >
                 Book a treatment
               </BookingButton>
               <Link
                 href="/treatments"
-                className="hidden md:inline-block font-sans text-sm text-cocoa underline underline-offset-2 hover:text-espresso transition-colors"
+                className="hidden font-sans text-sm underline transition-colors md:inline-block text-cocoa underline-offset-2 hover:text-espresso"
               >
                 Explore the menu →
               </Link>
             </div>
 
             {/* Trust row — tablet/desktop only (mobile renders after image below) */}
-            <div className="hidden md:flex flex-wrap items-center gap-5">
+            <div className="hidden flex-wrap gap-5 items-center md:flex">
               <TrustRowContent />
             </div>
           </div>
@@ -90,7 +90,7 @@ const MainHeader: React.FC = () => {
             />
 
             <div className="relative w-full max-w-[300px] sm:max-w-[440px] mx-auto">
-              <div className="relative w-full aspect-square md:aspect-[4/5] rounded-t-full overflow-hidden border border-clay/20">
+              <div className="overflow-hidden relative w-full rounded-t-full border aspect-square md:aspect-4/5 border-clay/20">
                 <Image
                   src="/images/mainPage/young-woman-having-face-massage-relaxing-spa-salon.jpg"
                   alt="Young woman receiving a relaxing face massage at Heavenly Treatments spa"
@@ -104,7 +104,7 @@ const MainHeader: React.FC = () => {
           </div>
 
           {/* Trust row — mobile only, 3rd flex item so it renders after image */}
-          <div className="md:hidden flex flex-wrap items-center gap-5">
+          <div className="flex flex-wrap gap-5 items-center md:hidden">
             <TrustRowContent />
           </div>
 

--- a/components/Sections/TreatmentsAccordion.tsx
+++ b/components/Sections/TreatmentsAccordion.tsx
@@ -7,23 +7,22 @@ import type { TreatmentCategory, TreatmentMenuItem } from '@/lib/data/treatments
 
 interface TreatmentsAccordionProps {
   categories: TreatmentCategory[];
-  initialCounts: Record<string, number>;
 }
 
 function SkeletonRows() {
   return (
-    <div className="px-5 sm:px-7 pb-2 sm:pb-3">
+    <div className="px-5 pb-2 sm:px-7 sm:pb-3">
       {[0, 1, 2].map((i) => (
         <div key={i} className="py-4 sm:py-5 border-t border-[rgba(74,64,56,0.1)]">
-          <div className="animate-pulse flex justify-between gap-6">
+          <div className="flex gap-6 justify-between animate-pulse">
             <div className="flex-1 space-y-2">
-              <div className="h-6 bg-stone rounded w-44" />
-              <div className="h-3 bg-stone rounded w-20" />
-              <div className="h-4 bg-stone rounded w-64 mt-1" />
+              <div className="w-44 h-6 rounded bg-stone" />
+              <div className="w-20 h-3 rounded bg-stone" />
+              <div className="mt-1 w-64 h-4 rounded bg-stone" />
             </div>
-            <div className="flex flex-col items-end gap-2 shrink-0">
-              <div className="h-6 bg-stone rounded w-12" />
-              <div className="h-3 bg-stone rounded w-20" />
+            <div className="flex flex-col gap-2 items-end shrink-0">
+              <div className="w-12 h-6 rounded bg-stone" />
+              <div className="w-20 h-3 rounded bg-stone" />
             </div>
           </div>
         </div>
@@ -32,7 +31,7 @@ function SkeletonRows() {
   );
 }
 
-export default function TreatmentsAccordion({ categories, initialCounts }: TreatmentsAccordionProps) {
+export default function TreatmentsAccordion({ categories }: TreatmentsAccordionProps) {
   const [openSlug, setOpenSlug] = useState<string | null>(null);
   const [cache, setCache] = useState<Record<string, TreatmentMenuItem[]>>({});
   const [loading, setLoading] = useState<Record<string, boolean>>({});
@@ -69,9 +68,6 @@ export default function TreatmentsAccordion({ categories, initialCounts }: Treat
         const headerId = `accordion-header-${category.slug}`;
         const treatments = cache[category.slug];
         const isLoading = loading[category.slug] ?? false;
-        const count = treatments !== undefined
-          ? treatments.length
-          : (initialCounts[category.slug] ?? null);
 
         return (
           <div
@@ -87,16 +83,11 @@ export default function TreatmentsAccordion({ categories, initialCounts }: Treat
               onClick={() => { void handleToggle(category.slug); }}
               className="w-full flex items-center gap-3 sm:gap-[18px] px-5 py-[18px] sm:px-7 sm:py-6 cursor-pointer text-left"
             >
-              {/* Mobile: name + count stacked, fills remaining space */}
+              {/* Mobile: name, fills remaining space */}
               <div className="flex-1 min-w-0 sm:hidden">
                 <span className="font-serif text-[22px] font-semibold text-[#3A332C] leading-tight block">
                   {category.name}
                 </span>
-                {count !== null && (
-                  <span className="text-[10.5px] tracking-[0.1em] uppercase text-sage font-semibold mt-[3px] block">
-                    {count} {count === 1 ? 'treatment' : 'treatments'}
-                  </span>
-                )}
               </div>
 
               {/* sm+ (tablet/desktop): name inline */}
@@ -109,20 +100,13 @@ export default function TreatmentsAccordion({ categories, initialCounts }: Treat
                 {category.shortDescription}
               </span>
 
-              {/* Count: tablet/desktop inline */}
-              {count !== null && (
-                <span className="hidden sm:block text-[11px] tracking-[0.12em] uppercase text-sage font-bold whitespace-nowrap shrink-0">
-                  {count} {count === 1 ? 'treatment' : 'treatments'}
-                </span>
-              )}
-
               {/* Toggle indicator — aria-hidden since button already has aria-expanded */}
               <span
                 aria-hidden="true"
                 className={
                   isOpen
-                    ? 'flex items-center justify-center w-[30px] h-[30px] sm:w-8 sm:h-8 rounded-full bg-sage text-warm-white text-[21px] leading-none shrink-0 select-none'
-                    : 'flex items-center justify-center w-[30px] h-[30px] sm:w-8 sm:h-8 rounded-full border border-clay text-sage text-[19px] leading-none shrink-0 select-none'
+                    ? 'flex justify-center items-center leading-none rounded-full select-none w-[30px] h-[30px] sm:w-8 sm:h-8 bg-sage text-warm-white text-[21px] shrink-0'
+                    : 'flex justify-center items-center leading-none rounded-full border select-none w-[30px] h-[30px] sm:w-8 sm:h-8 border-clay text-sage text-[19px] shrink-0'
                 }
               >
                 {isOpen ? '−' : '+'}
@@ -139,7 +123,7 @@ export default function TreatmentsAccordion({ categories, initialCounts }: Treat
                 {isLoading ? (
                   <SkeletonRows />
                 ) : treatments && treatments.length > 0 ? (
-                  <div className="px-5 sm:px-7 pb-2 sm:pb-3">
+                  <div className="px-5 pb-2 sm:px-7 sm:pb-3">
                     {treatments.map((item) => (
                       <Link
                         key={item.id}
@@ -149,7 +133,7 @@ export default function TreatmentsAccordion({ categories, initialCounts }: Treat
                         {/* Left: name (+ mobile price), duration, description */}
                         <div className="flex-1 min-w-0">
                           {/* Mobile: name + price on same baseline row */}
-                          <div className="flex justify-between items-baseline gap-3 sm:block">
+                          <div className="flex gap-3 justify-between items-baseline sm:block">
                             <p className="font-serif text-[20px] sm:text-[23px] font-semibold text-[#3A332C] mb-0 sm:mb-[5px] leading-snug">
                               {item.name}
                             </p>
@@ -158,7 +142,7 @@ export default function TreatmentsAccordion({ categories, initialCounts }: Treat
                               {item.price}
                             </span>
                           </div>
-                          <p className="text-[10.5px] sm:text-[11.5px] tracking-[0.1em] sm:tracking-[0.12em] uppercase text-sage font-semibold mb-[6px] sm:mb-[9px]">
+                          <p className="text-[10.5px] sm:text-[11.5px] tracking-widest sm:tracking-[0.12em] uppercase text-sage font-semibold mb-[6px] sm:mb-[9px]">
                             {item.durationLabel}
                           </p>
                           <p className="text-[13px] sm:text-[14px] leading-[1.55] sm:leading-[1.6] text-taupe max-w-[460px]">
@@ -167,7 +151,7 @@ export default function TreatmentsAccordion({ categories, initialCounts }: Treat
                         </div>
 
                         {/* Right: price (tablet/desktop) + "View details" (desktop only) */}
-                        <div className="hidden sm:flex flex-col items-end gap-1 shrink-0">
+                        <div className="hidden flex-col gap-1 items-end sm:flex shrink-0">
                           <span className="font-serif text-[22px] text-sage font-semibold whitespace-nowrap">
                             {item.price}
                           </span>


### PR DESCRIPTION
## Summary

- Full redesign of `/treatments/[categorySlug]` to match the Sanctuary design spec (5-section layout)
- Remove treatment counters from all pages
- Add mobile back navigation to category pages
- Fix pre-existing bugs found in working tree (broken import, corrupted Tailwind class, truncated heading)

## Changes

### Category page redesign (`app/treatments/[categorySlug]/page.tsx`)
Complete structural rewrite from a basic page to the Sanctuary 5-section layout:
1. **Breadcrumb / back nav** — desktop breadcrumb trail + mobile `← Treatments` link
2. **Hero** — eyebrow, H1, description, price/duration stats row, Book CTA, pill-top image with decorative circle
3. **Treatment menu** — mobile cards + tablet/desktop unified list with name, duration, description, price
4. **Explore other collections** — mobile vertical stack / tablet 2-col / desktop 4-col grid
5. **Green CTA block** — "Not sure which to choose?" with contact link

### Counter removal
- `TreatmentsAccordion.tsx` — removed `initialCounts` prop, `count` variable, and mobile/desktop count spans
- `app/treatments/page.tsx` — removed `getTreatmentCountsByCategory` import and parallel fetch
- Category page — removed count badge from menu heading and "other collections" cards

### Bug fixes (found in working tree, pre-dating this session)
- `app/about/page.tsx` — broken import `AboutPullQuote.1` → `AboutPullQuote`
- `components/Layout/BookingCtaBand.tsx` — truncated h2 text restored; `shrink-0-serif` (corrupted class) → `shrink-0 font-serif`

## Test plan

- [ ] Visit `/treatments/massages` (or any category) on mobile — confirm `← Treatments` back link appears below navbar
- [ ] Check desktop breadcrumb still renders (`Home / Treatments / Massages`)
- [ ] Verify no treatment counters appear anywhere on `/treatments` accordion or category pages
- [ ] Check stats row shows only Price and Duration (not a count)
- [ ] Confirm "Explore other collections" grid renders on tablet/desktop
- [ ] Visit `/about` page — confirm it loads without errors (broken import fixed)
- [ ] Check BookingCtaBand heading reads "Your journey to relaxation starts here"

🤖 Generated with [Claude Code](https://claude.com/claude-code)