### PR TITLE
feat(cms): add devOnly flag to treatments

### DIFF
--- a/lib/sanity/queries.ts
+++ b/lib/sanity/queries.ts
@@ -1,12 +1,16 @@
 import { groq } from 'next-sanity';
 
+// In production, hide treatments flagged as dev-only. In development all are shown.
+// GROQ: `null != true` evaluates to true, so treatments without the field are unaffected.
+const devFilter = process.env.NODE_ENV === 'development' ? '' : '&& devOnly != true';
+
 /**
  * GROQ query: treatment count per category slug, no treatment payload fetched
  */
 export const treatmentCountsByCategoryQuery = groq`
   *[_type == "treatmentCategory"] {
     "slug": slug.current,
-    "count": count(*[_type == "treatment" && references(^._id)])
+    "count": count(*[_type == "treatment" && references(^._id) ${devFilter}])
   }
 `;
 
@@ -45,7 +49,7 @@ export const categoryBySlugQuery = groq`
  * GROQ query to fetch all treatments with their category details
  */
 export const allTreatmentsQuery = groq`
-  *[_type == "treatment"] | order(_createdAt desc) {
+  *[_type == "treatment" ${devFilter}] | order(_createdAt desc) {
     _id,
     title,
     "slug": slug.current,
@@ -67,7 +71,7 @@ export const allTreatmentsQuery = groq`
  * GROQ query to fetch a single treatment by slug
  */
 export const treatmentBySlugQuery = groq`
-  *[_type == "treatment" && slug.current == $slug][0] {
+  *[_type == "treatment" && slug.current == $slug ${devFilter}][0] {
     _id,
     title,
     "slug": slug.current,
@@ -93,7 +97,7 @@ export const treatmentBySlugQuery = groq`
  * GROQ query to fetch treatments by category slug
  */
 export const treatmentsByCategoryQuery = groq`
-  *[_type == "treatment" && category->slug.current == $categorySlug] {
+  *[_type == "treatment" && category->slug.current == $categorySlug ${devFilter}] {
     _id,
     title,
     "slug": slug.current,
@@ -118,7 +122,7 @@ export const treatmentsByCategoryQuery = groq`
  * lazy-loaded accordion menu renders (no image asset).
  */
 export const treatmentsMenuByCategoryQuery = groq`
-  *[_type == "treatment" && category->slug.current == $categorySlug] {
+  *[_type == "treatment" && category->slug.current == $categorySlug ${devFilter}] {
     _id,
     title,
     "slug": slug.current,
@@ -133,7 +137,7 @@ export const treatmentsMenuByCategoryQuery = groq`
  * GROQ query to fetch all treatment slugs for static generation
  */
 export const allTreatmentSlugsQuery = groq`
-  *[_type == "treatment"] {
+  *[_type == "treatment" ${devFilter}] {
     "slug": slug.current,
     "categorySlug": category->slug.current
   }

--- a/lib/sanity/types.ts
+++ b/lib/sanity/types.ts
@@ -76,4 +76,5 @@ export interface SanityTreatment {
     slug: string;
   };
   freshaUrl?: string;
+  devOnly?: boolean;
 }

--- a/sanity/schemas/treatment.ts
+++ b/sanity/schemas/treatment.ts
@@ -116,6 +116,13 @@ export default defineType({
         scheme: ['http', 'https'],
       }),
     }),
+    defineField({
+      name: 'devOnly',
+      title: 'Dev Only',
+      type: 'boolean',
+      description: '⚠️ When enabled, this treatment is hidden from the live site and only visible in development. Use this while building out new treatments before they are ready to go live.',
+      initialValue: false,
+    }),
   ],
   preview: {
     select: {
@@ -123,11 +130,12 @@ export default defineType({
       subtitle: 'price',
       media: 'image',
       category: 'category.name',
+      devOnly: 'devOnly',
     },
     prepare(selection) {
-      const { title, subtitle, media, category } = selection;
+      const { title, subtitle, media, category, devOnly } = selection;
       return {
-        title,
+        title: devOnly ? `[DEV] ${title}` : title,
         subtitle: `${category} - ${subtitle}`,
         media,
       };


### PR DESCRIPTION
## Summary

Adds a `devOnly` boolean field to the Sanity `treatment` document so treatments in progress can be added to the CMS without appearing on the live site.

## Changes

- **`sanity/schemas/treatment.ts`** — new `devOnly` boolean field (defaults `false`); Studio list preview prefixes title with `[DEV]` when enabled
- **`lib/sanity/queries.ts`** — all 6 treatment queries append `&& devOnly != true` in production; development shows everything
- **`lib/sanity/types.ts`** — `devOnly?: boolean` added to `SanityTreatment`

## How it works

```
NODE_ENV === 'development'  →  no filter, all treatments visible
NODE_ENV === 'production'   →  devOnly != true appended to every GROQ query
```

`null != true` evaluates to `true` in GROQ, so existing treatments without the field set are unaffected — no data migration needed.

The filter is applied to: `allTreatmentsQuery`, `treatmentBySlugQuery`, `treatmentsByCategoryQuery`, `treatmentsMenuByCategoryQuery`, `allTreatmentSlugsQuery`, and the nested count inside `treatmentCountsByCategoryQuery` — meaning dev-only treatments are also excluded from static path generation and category counts in production.

## Test plan

- [x] `npm run test` — 134 tests pass
- [x] `npm run typecheck` — no new errors
- [ ] Run `npm run sanity:deploy` to push the new schema field to the Sanity project

🤖 Generated with [Claude Code](https://claude.com/claude-code)